### PR TITLE
fix: fix drag & drop for submenu action

### DIFF
--- a/build/sea.bat
+++ b/build/sea.bat
@@ -1,5 +1,5 @@
+node -e "require('fs').writeFileSync('dist/version.txt', require('./package.json').version)"
 call npm run build:bundle
 node --experimental-sea-config build/sea-config.json
-node -e "require('fs').writeFileSync('dist/version.txt', require('./package.json').version)"
 node -e "require('fs').copyFileSync(process.execPath, 'dist/sc4.exe')"
 call npm run build:postject

--- a/lib/cli/flows/submenu-flow.js
+++ b/lib/cli/flows/submenu-flow.js
@@ -61,7 +61,7 @@ export async function submenu() {
 	let outputDir;
 	let [first] = files;
 	let info = fs.statSync(first);
-	if (info.isDirectory) {
+	if (info.isDirectory()) {
 		outputDir = first;
 	} else {
 		outputDir = path.dirname(first);


### PR DESCRIPTION
When dragging multiple files onto the exe for the submenu command, the file could not be saved because the output directory was incorrectly set as the first file *itself*.