### PR TITLE
fix: require menu option

### DIFF
--- a/lib/cli/setup-cli.js
+++ b/lib/cli/setup-cli.js
@@ -76,7 +76,7 @@ export function factory(program) {
 		.command('create-submenu-patch')
 		.argument('[files...]', 'The files or directories to scan. Can also be a glob pattern. Defaults to the current working directory')
 		.description('Adds all specified lots to the given menu using the Exemplar Patching method')
-		.option('-m, --menu [button id]', 'The button ID of the submenu, e.g. 0x83E040BB for highway signage.')
+		.requiredOption('-m, --menu [button id]', 'The button ID of the submenu, e.g. 0x83E040BB for highway signage.')
 		.option('-o, --output [file]', 'Path to the output file. Defaults to "Submenu patch.dat".')
 		.option('-d, --directory [dir]', 'The directory where the files are located. Defaults to current work directory')
 		.option('--instance [IID]', 'The instance id (IID) to use for the patch, random by default.')


### PR DESCRIPTION
The `create-submenu-patch` command could be called without the required menu argument. We now throw an error if this happens.