### PR TITLE
fix: custom menu button ids are broken

### DIFF
--- a/lib/cli/flows/submenu-flow.js
+++ b/lib/cli/flows/submenu-flow.js
@@ -48,11 +48,10 @@ export async function submenu() {
 		},
 	});
 	if (menu === 'custom') {
-		({ menu } = await prompts.hex({
+		menu = +await prompts.hex({
 			name: 'menu',
 			message: 'Input a custom button id (e.g 0x5c43f355)',
-		}));
-		menu = +menu;
+		});
 	}
 
 	// Ask where to save the patch. This is a bit difficult because we need to 


### PR DESCRIPTION
Inputing a custom menu button id didn't work anymore after we migrated inquirer. It always added `0x00000000` to the Exemplar. This fixes it.