### PR TITLE
fix: use `LotResourceKey` for submenus

### DIFF
--- a/lib/api/create-submenu-patch.js
+++ b/lib/api/create-submenu-patch.js
@@ -99,23 +99,20 @@ export default async function createMenuPatch(menu, globsOrFiles, options = {}) 
 }
 
 // # collect(dbpf)
-// Collect all [group, instance] pairs from the *building* exemplars in a dbpf 
-// file that have "Item Icon" (0x8A2602B8) set, meaning they show up in a menu.
+// Collect all [group, instance] pairs from the lots that appear in a lot. Note 
+// that this is harder than it sounds because the properties we're looking for 
+// might actually be stored in a parent cohort. We'll hence look for the 
+// LotResourceKey, which is more or less guaranteed to not be stored in a parent 
+// cohort - though it technically could be.
 function collect(dbpf, logger) {
 	let gis = [];
 	let entries = dbpf.entries.filter(entry => entry.type === FileType.Exemplar);
 	for (let entry of entries) {
-
-		// Check if the exemplar is a building exemplar
+		
+		// Check if the LotResourceKey exists.
 		let ex = entry.read();
-		let isBuilding = ex.props.some(prop => {
-			return prop.id === 0x10 && prop.value === 0x02;
-		});
-		if (!isBuilding) continue;
-
-		// Ensure the exemplar has an icon set, meaning it appears in a menu.
-		let hasIcon = ex.props.some(prop => prop.id === 0x8A2602B8);
-		if (!hasIcon) continue;
+		let hasLotResourceKey = ex.props.some(prop => prop.id === 0xea260589);
+		if (!hasLotResourceKey) continue;
 
 		// Cool, this is an item that appears in a menu, grab its tgi and add 
 		// the group and instance to what we're collecting.


### PR DESCRIPTION
While investigating the airport set, we've noticed that some lots specify the exemplar type in a parent cohort, which we were not reading in. Hence we now use the `LotResourceKey` instead to determine whether a lot appears in a menu or not.