### PR TITLE
fix: add experimental support for Node 18

### DIFF
--- a/lib/cli/version.js
+++ b/lib/cli/version.js
@@ -21,6 +21,7 @@ function isSea() {
 		return false;
 	} else {
 		const sea = getSea();
+		if (!sea) return false;
 		return sea.isSea();
 	}
 }

--- a/lib/cli/version.js
+++ b/lib/cli/version.js
@@ -1,14 +1,27 @@
 // # version.js
-import sea from 'node:sea';
 import fs from 'node:fs';
 import { packageUpSync } from 'package-up';
 
 function getVersion() {
-	if (sea.isSea()) {
+	if (isSea()) {
+		const sea = getSea();
 		return sea.getAsset('version.txt', 'utf8');
 	} else {
 		const pkg = packageUpSync({ cwd: import.meta.dirname });
 		return JSON.parse(fs.readFileSync(pkg)).version;
+	}
+}
+
+function getSea() {
+	return process.getBuiltinModule('node:sea');
+}
+
+function isSea() {
+	if (!globalThis.process?.getBuiltinModule) {
+		return false;
+	} else {
+		const sea = getSea();
+		return sea.isSea();
 	}
 }
 export default getVersion();


### PR DESCRIPTION
This PR adds experimental support for Node 18 by not importing the `node:sea` module - which is not available on Node 18 - but by relying on `process.getBuiltinModule`.