### PR TITLE
fix: ignore case when scanning directories on Linux

### DIFF
--- a/lib/api/create-submenu-patch.js
+++ b/lib/api/create-submenu-patch.js
@@ -32,6 +32,7 @@ export default async function createMenuPatch(menu, globsOrFiles, options = {}) 
 					nodir: true,
 					absolute: true,
 					cwd: fullPath,
+					nocase: true,
 				})) files.add(file);
 			} else {
 				files.add(fullPath);


### PR DESCRIPTION
This PR fixes a bug that caused the scanning of directories to happen in a case sensitive way on Linux (given that Linux has a case-sensitive filesystem). It is fixes by passing the `nocase` option to `true` explicitly when globbing (which was the default on Windows and Mac).