### PR TITLE
ci: setup publish to npm job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ on:
 jobs:
   release:
     runs-on: windows-latest
-    permissions:
-      contents: write
-      id-token: write
     outputs:
       url: ${{ steps.gh-release.outputs.upload_url }}
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
@@ -114,3 +111,23 @@ jobs:
           -H "Content-Type: application/octet-stream" \
           $UPLOAD_URL \
           --data-binary "@$ASSET_PATH"
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          registry-url: "https://registry.npmjs.org"
+      - id: read-version
+        name: Read version
+        uses: ./.github/actions/get-version
+      - name: Publish
+        run: npm publish --provenance --tag ${{ steps.read-version.outputs.npm-tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
Try to get the publish to npm working, for some reason it doesn't want to do it inside the main release task.