### PR TITLE
fix: fix crash on startup on Linux

### DIFF
--- a/lib/api/city-manager.js
+++ b/lib/api/city-manager.js
@@ -1,5 +1,5 @@
 // # city-manager.js
-import { path, fs } from 'sc4/utils';
+import { path, fs, os } from 'sc4/utils';
 import {
 	Savegame,
 	Lot,
@@ -9,7 +9,7 @@ import {
 	Pointer,
 	FileType,
 } from 'sc4/core';
-const SC4 = path.resolve(process.env.HOMEPATH, 'documents/SimCity 4');
+const SC4 = path.resolve(os ? os.homedir() : '/', 'documents/SimCity 4');
 const regions = path.join(SC4, 'regions');
 
 // Hex constants to make the code more readable.

--- a/lib/api/file-index.js
+++ b/lib/api/file-index.js
@@ -62,7 +62,7 @@ export default class FileIndex {
 		// of course.
 		if (!opts.files && !opts.dirs) {
 			let plugins = path.join(
-				process.env.HOMEPATH,
+				os.homedir(),
 				'Documents/SimCity 4/Plugins',
 			);
 			opts = {

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -1,8 +1,9 @@
 // # config.js
-import Conf from 'conf';
-import { parse, stringify } from 'yaml';
+import os from 'node:ofs';
 import path from 'node:path';
 import fs from 'node:fs';
+import Conf from 'conf';
+import { parse, stringify } from 'yaml';
 
 const config = new Conf({
 	projectName: 'sc4',
@@ -14,7 +15,7 @@ export default config;
 
 // Verify that a plugins folder has been set.
 if (!config.get('folders.plugins')) {
-	let plugins = path.resolve(process.env.HOMEPATH, 'Documents/SimCity 4/Plugins');
+	let plugins = path.resolve(os.homedir(), 'Documents/SimCity 4/Plugins');
 	if (fs.existsSync(plugins)) {
 		config.set('folders.plugins', plugins);
 	}

--- a/lib/cli/folders.js
+++ b/lib/cli/folders.js
@@ -1,4 +1,5 @@
 // # folders.js
+import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
 import config from './config.js';
@@ -13,7 +14,7 @@ export default {
 function getPlugins() {
 	const fromConfig = config.get('folders.plugins');
 	if (fromConfig) return fromConfig;
-	let plugins = path.resolve(process.env.HOMEPATH, 'Documents/SimCity 4/Plugins');
+	let plugins = path.resolve(os.homedir(), 'Documents/SimCity 4/Plugins');
 	if (!fs.existsSync(plugins)) {
 		return process.cwd();
 	}

--- a/lib/cli/prompts/index.js
+++ b/lib/cli/prompts/index.js
@@ -1,6 +1,7 @@
 // # prompts/index.js
 import path from 'node:path';
 import fs from 'node:fs';
+import os from 'node:os';
 import { makeTheme } from '@inquirer/core';
 import input from '@inquirer/input';
 import confirm from '@inquirer/confirm';
@@ -41,7 +42,7 @@ export function uint32(opts) {
 // if the current working directory contains .sc4 files, then we use that one. 
 // Otherwise we open the regions folder.
 const regions = path.resolve(
-	process.env.HOMEPATH ?? '/',
+	os.homedir() ?? '/',
 	'Documents/SimCity 4/Regions',
 );
 export async function city(opts = {}) {

--- a/lib/cli/setup-cli.js
+++ b/lib/cli/setup-cli.js
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import os from 'node:os';
 import chalk from 'chalk';
 import tar from 'tar';
 import ora from 'ora';
@@ -218,7 +219,7 @@ export function factory(program) {
 		.action(async function() {
 
 			// Find the user's home directory.
-			const home = process.env.HOMEPATH;
+			const home = os.homedir();
 			const docs = path.join(home, 'documents/SimCity 4');
 			
 			// Check if either plugins or region was specified.

--- a/lib/core/test/dbpf-test.js
+++ b/lib/core/test/dbpf-test.js
@@ -304,8 +304,6 @@ describe('A lot subfile', function() {
 
 	it('should re-save after making buildings historical', async function() {
 		let file = resource('city.sc4');
-		// let file = resource('writing_history.sc4');
-		// let file = path.resolve(process.env.HOMEPATH, 'documents/SimCity 4/Regions/Experiments/City - Writing More History.sc4');
 		let buff = fs.readFileSync(file);
 		let dbpf = new DBPF(buff);
 

--- a/lib/gui/gui.js
+++ b/lib/gui/gui.js
@@ -1,4 +1,5 @@
 "use strict";
+const os = require('os');
 const three = require('three');
 const path = require('path');
 const fs = require('fs');
@@ -19,9 +20,7 @@ document.body.append(renderer.el);
 
 // Append a box.
 
-// let file = path.resolve(__dirname, '../../test/files/city.sc4');
-// let file = path.resolve(process.env.HOMEPATH, 'Documents/SimCity 4/Regions/Experiments/City - Skyline.sc4');
-let file = path.resolve(process.env.HOMEPATH, 'Documents/SimCity 4/Regions/Experiments/City - Plopsaland.sc4');
+let file = path.resolve(os.homedir(), 'Documents/SimCity 4/Regions/Experiments/City - Plopsaland.sc4');
 let dbpf = new Savegame(fs.readFileSync(file));
 
 // Read all buildings.

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -5,6 +5,7 @@ const MS_DAY = 60*60*24*1000;
 
 // Export the node-builtins, taking into account that they might not be 
 // available if we're running in the browser.
+import { os, util } from './node-builtins.js';
 export * from './node-builtins.js';
 
 // # getUnixFromJulian(d)
@@ -52,7 +53,6 @@ hex.register = function() {
 	if (!Number.prototype.hex) {
 		// eslint-disable-next-line no-extend-native
 		Number.prototype.hex = function(...args) {
-			const util = process.getBuiltinModule('util');
 			return util.styleText('yellow', hex(this, ...args));
 		};
 	}
@@ -142,7 +142,7 @@ export function getCityPath(city, region = 'Experiments') {
 	const path = process.getBuiltinModule('path');
 	let file = `City - ${city}.sc4`;
 	return path.resolve(
-		process.env.USERPROFILE,
+		os.homedir(),
 		'documents/SimCity 4/Regions',
 		region,
 		file,


### PR DESCRIPTION
This PR fixes a crash on startup on Linux because we passed `undefined` to `path.resolve()`. That's because `process.env.HOMEPATH` is undefined on Linux. Hence we removed all occurrences of `process.env.HOMEPATH` and replaced them with `os.homedir()` instead.