### PR TITLE
fix: fix pasting images for in icons prompt

### DIFF
--- a/lib/cli/assets/script.js
+++ b/lib/cli/assets/script.js
@@ -230,17 +230,21 @@ dropArea.addEventListener('drop', e => {
 
 // Handle paste events.
 window.addEventListener('paste', e => {
+	let [file] = e.clipboardData.files;
+	if (file) {
+		setFile(file);
+		return;
+	}
+
+	// If no files were pasted, but only text, then treat it as a url being 
+	// pasted.
 	let [item] = e.clipboardData.items;
 	if (item.kind === 'string') {
 		let text = e.clipboardData.getData('text');
 		try {
-			set(sourceImage = null, templated = true);
 			fetchUrl(new URL(text));
+			set(sourceImage = null, templated = true);
 		} catch {}
-	} else {
-		set(sourceImage = null, templated = true);
-		input.files = e.clipboardData.files;
-		setFile(input.files[0]);
 	}
 });
 
@@ -252,7 +256,7 @@ $templated.addEventListener('input', event => {
 // Get the configuration data.
 let config = await fetch('/data').then(res => res.json());
 message = config.message;
-templated = config.templated;
+templated = config.templated || true;
 if (config.default) {
 	fetchUrl(new URL(config.default));
 }


### PR DESCRIPTION
This PR fixes a small bug that prevent some images from being pasted into the browser icon selector flow. When pasting an image, the data on the clipboard may also contain textual data, which we tried to parse as a url - which failed obviously. Hence we now always check for any files first. Only when the pasted data does not contain any files, we try to parse it as a url.