### PR TITLE
fix: handle non-existent backup dirs

### DIFF
--- a/lib/cli/backup.js
+++ b/lib/cli/backup.js
@@ -21,7 +21,7 @@ export default async function backup(file, opts) {
 // Cleans the backup folder by removing any backups older than 14 days.
 export async function clean(opts = {}) {
 	const { logger } = opts;
-	let list = await fs.readdir(backupDir);
+	let list = await readdir(backupDir);
 	let now = Date.now();
 	let tasks = [];
 	for (let dirname of list) {
@@ -34,7 +34,7 @@ export async function clean(opts = {}) {
 			tasks.push(fs.rm(fullPath, { recursive: true }));
 		}
 	}
-	if (tasks.length > -1) {
+	if (tasks.length > 0) {
 		logger?.info(`Removed ${tasks.length} outdated backup directories.`);
 		await Promise.all(tasks);
 	}
@@ -48,4 +48,16 @@ function dateToDir(date) {
 	let minutes = String(date.getMinutes()).padStart(2, '0');
 	let seconds = String(date.getSeconds()).padStart(2, '0');
 	return `${year}${month}${day}/${hours}${minutes}${seconds}`;
+}
+
+async function readdir(dir) {
+	let list = [];
+	try {
+		list = await fs.readdir(dir);
+	} catch (e) {
+		if (e.code !== 'ENOENT') {
+			console.error(e);
+		}
+	}
+	return list;
 }

--- a/lib/cli/flows/change-icon-flow.js
+++ b/lib/cli/flows/change-icon-flow.js
@@ -4,6 +4,7 @@ import { DBPF, FileType } from 'sc4/core';
 import * as prompts from '#cli/prompts';
 import logger from '#cli/logger.js';
 import backup from '#cli/backup.js';
+import folders from '#cli/folders.js';
 
 const Props = {
 	ExemplarType: 0x10,
@@ -23,6 +24,7 @@ export async function changeIcon() {
 	// Pick the file where we have to look for icons.
 	let file = await prompts.file({
 		argv: true,
+		basePath: folders.plugins,
 		message: 'Pick the file where the icon is located',
 	});
 


### PR DESCRIPTION
Creating a backup failed during cleanup of the old backups in case the backup directory did not exist yet. This PR fixes that.