### PR TITLE
feat: serialize menu config as hex

### DIFF
--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -3,13 +3,30 @@ import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
 import Conf from 'conf';
-import { parse, stringify } from 'yaml';
+import { parse, Document } from 'yaml';
+
+// # serialize(config)
+// This function is responsible for serializing the config file. Note that 
+// instead of just serializing the yaml, we will make sure that some values are 
+// stored as hex values, as that's more in line with the values people are used 
+// to.
+function serialize(config) {
+	let doc = new Document(config);
+	let menus = doc.get('menus', true);
+	if (menus) {
+		for (let obj of menus.items) {
+			(obj.get('id', true) ?? {}).format = 'HEX';
+			(obj.get('parent', true) ?? {}).format = 'HEX';
+		}
+	}
+	return doc.toString();
+}
 
 const config = new Conf({
 	projectName: 'sc4',
 	fileExtension: 'yaml',
 	deserialize: parse,
-	serialize: stringify,
+	serialize,
 });
 export default config;
 


### PR DESCRIPTION
This PR ensures that menu ids and parent menu ids are properly serialized as hex numbers in the config, as this fits better with what people are used to.