### PR TITLE
refactor!: use builtin classes for property types

### DIFF
--- a/lib/core/exemplar.js
+++ b/lib/core/exemplar.js
@@ -7,64 +7,68 @@ import NAMES from './exemplar-props.js';
 import FileType from './file-types.js';
 import LotObject from './lot-object.js';
 import { ExemplarProperty } from './enums.js';
-import { makeEnum, invert, hex, inspect } from 'sc4/utils';
+import { invertMap, hex, inspect } from 'sc4/utils';
 
 const LotObjectRange = [
 	ExemplarProperty.LotConfigPropertyLotObject,
 	ExemplarProperty.LotConfigPropertyLotObject+1279,
 ];
 
-const Type = makeEnum([
-	'Byte', 'Uint16', 'Uint32', 'Int32', 'BigInt64', 'Boolean', 'Float',
-	'String',
+// We no longer use an enum for indicating the type of an exemplar property. 
+// Instead we use the native built-in JavaScript typed arrays to indicate the 
+// type of a property, as there is no "Uint32" *type* in JavaScript. To make it 
+// a bit more readable though, we'll create aliases because Uint32Array might 
+// indicate that the type *has* to be an array, but that is not the case 
+// actually. It onl indicates that the *values* are Uint32!s
+const Uint8 = Uint8Array;
+const Uint16 = Uint16Array;
+const Uint32 = Uint32Array;
+const Sint32 = Int32Array;
+const Sint64 = globalThis.BigInt64Array;
+const Float32 = Float32Array;
+const Bool = Boolean;
+
+const TYPE_TO_HEX = new Map([
+	[Uint8, 0x100],
+	[Uint16, 0x200],
+	[Uint32, 0x300],
+	[Sint32, 0x700],
+	[Sint64, 0x800],
+	[Float32, 0x900],
+	[Bool, 0xB00],
+	[String, 0xc00],
+]);
+const HEX_TO_TYPE = invertMap(TYPE_TO_HEX);
+
+function getByteLengthFromType(type) {
+	if ('BYTES_PER_ELEMENT' in type) {
+		return type.BYTES_PER_ELEMENT;
+	} else {
+		return 1;
+	}
+}
+
+const VALUE_READERS = new Map([
+	[Uint8, rs => rs.uint8()],
+	[Uint16, rs => rs.uint16()],
+	[Uint32, rs => rs.uint32()],
+	[Sint32, rs => rs.int32()],
+	[Sint64, rs => rs.bigint64()],
+	[Float32, rs => rs.float()],
+	[Bool, rs => Boolean(rs.uint8())],
+	[String, (rs, length) => rs.string(length)],
 ]);
 
-const TYPE_TO_HEX = Object.freeze({
-	[Type.Int32]: 0x700,
-	[Type.Uint32]: 0x300,
-	[Type.Float]: 0x900,
-	[Type.Boolean]: 0xB00,
-	[Type.Byte]: 0x100,
-	[Type.BigInt64]: 0x800,
-	[Type.Uint16]: 0x200,
-	[Type.String]: 0xc00,
-});
-const HEX_TO_TYPE = Object.freeze(invert(TYPE_TO_HEX));
-const TYPE_TO_SIZE = Object.freeze({
-	[Type.Int32]: 4,
-	[Type.Uint32]: 4,
-	[Type.Float]: 4,
-	[Type.Boolean]: 1,
-	[Type.Byte]: 1,
-	[Type.BigInt64]: 8,
-	[Type.Uint16]: 2,
-
-	// This is for legacy purposes.
-	[Type.String]: 1,
-
-});
-
-const VALUE_READERS = Object.freeze({
-	[Type.Int32]: rs => rs.int32(),
-	[Type.Uint32]: rs => rs.uint32(),
-	[Type.Float]: rs => rs.float(),
-	[Type.Boolean]: rs => Boolean(rs.uint8()),
-	[Type.Byte]: rs => rs.uint8(),
-	[Type.BigInt64]: rs => rs.bigint64(),
-	[Type.Uint16]: rs => rs.uint16(),
-	[Type.String]: (rs, length) => rs.string(length),
-});
-
-const VALUE_WRITERS = Object.freeze({
-	[Type.Int32]: (buff, ...rest) => buff.writeInt32LE(...rest),
-	[Type.Uint32]: (buff, ...rest) => buff.writeUInt32LE(...rest),
-	[Type.Float]: (buff, ...rest) => buff.writeFloatLE(...rest),
-	[Type.Boolean]: (buff, value, ...rest) => buff.writeUInt8(Number(value), ...rest),
-	[Type.Byte]: (buff, ...rest) => buff.writeUInt8(...rest),
-	[Type.BigInt64]: (buff, ...rest) => buff.writeBigInt64LE(...rest),
-	[Type.Uint16]: (buff, ...rest) => buff.writeUInt16(...rest),
-	[Type.String]: (buff, ...rest) => buff.write(...rest),
-});
+const VALUE_WRITERS = new Map([
+	[Uint8, (buff, ...rest) => buff.writeUInt8(...rest)],
+	[Uint16, (buff, ...rest) => buff.writeUInt16(...rest)],
+	[Uint32, (buff, ...rest) => buff.writeUInt32LE(...rest)],
+	[Sint32, (buff, ...rest) => buff.writeInt32LE(...rest)],
+	[Sint64, (buff, ...rest) => buff.writeBigInt64LE(...rest)],
+	[Float32, (buff, ...rest) => buff.writeFloatLE(...rest)],
+	[Bool, (buff, value, ...rest) => buff.writeUInt8(Number(value), ...rest)],
+	[String, (buff, ...rest) => buff.write(...rest)],
+]);
 
 // # Exemplar()
 // See https://www.wiki.sc4devotion.com/index.php?title=EXMP for the spec.
@@ -182,20 +186,20 @@ export class Exemplar {
 	// Adds a property to the exemplar file. Note that we automatically use 
 	// Uint32 as a default for numbers, but this can obviously be set to 
 	// something specific.
-	addProperty(id, value, typeHint = 'Uint32') {
+	addProperty(id, value, typeHint = Uint32) {
 		let type;
 		if (typeof value === 'string') {
-			type = Type.String;
+			type = String;
 		} else if (typeof value === 'bigint') {
-			type = Type.BigInt64;
+			type = BigInt64Array;
 		} else if (typeof value === 'boolean') {
-			type = Type.Boolean;
+			type = Boolean;
 		} else {
 			type = typeHint;
 		}
 		let prop = new Property({
 			id,
-			type: Type[type] || type,
+			type,
 			value,
 		});
 		this.props.push(prop);
@@ -243,14 +247,17 @@ export class Exemplar {
 	parseFromString(str) {
 		let obj = parseString(str);
 		this.parent = obj.parent;
-		this.props = obj.props.map(function(def) {
-			let type = Type[({
-				Uint8: 'Byte',
-				Float32: 'Float',
-				Sint64: 'BigInt64',
-				Sint32: 'Int32',
-				Bool: 'Boolean',
-			})[ def.type ] || def.type];
+		this.props = obj.props.map(def => {
+			let type = ({
+				Uint8,
+				Uint16,
+				Uint32,
+				Sint32,
+				Sint64,
+				Float32,
+				Bool,
+				String,
+			})[def.type];
 			return new Property({
 				id: def.id,
 				type,
@@ -345,7 +352,7 @@ class Property {
 	// If the data passed is a property, then we'll use a *clone* strategy.
 	constructor(data = {}) {
 		let isClone = data instanceof Property;
-		let { id = 0, type = Type.Uint32, value } = data;
+		let { id = 0, type = Uint32Array, value } = data;
 		this.id = +id;
 		this.type = type;
 		this.value = isClone ? structuredClone(value) : value;
@@ -372,7 +379,7 @@ class Property {
 
 	// ## get hexType()
 	get hexType() {
-		return TYPE_TO_HEX[this.type];
+		return TYPE_TO_HEX.get(this.type);
 	}
 
 	// ## get keyType()
@@ -393,7 +400,7 @@ class Property {
 	// multiple values because we need to store the string length here!
 	get byteLength() {
 		let { type, value } = this;
-		let bytes = TYPE_TO_SIZE[type];
+		let bytes = getByteLengthFromType(type);
 		return this.multiple ? (4 + value.length * bytes) : bytes;
 	}
 
@@ -406,8 +413,8 @@ class Property {
 
 		// Parse value type & associated reader.
 		let nr = rs.uint16();
-		let type = this.type = HEX_TO_TYPE[nr];
-		let reader = VALUE_READERS[type];
+		let type = this.type = HEX_TO_TYPE.get(nr);
+		let reader = VALUE_READERS.get(type);
 
 		// Parse key type.
 		let keyType = rs.uint16();
@@ -422,7 +429,7 @@ class Property {
 			// If we're dealing with a string, read the string. Otherwise 
 			// read the values using the repetitions. Note that this means 
 			// that strings can't be repeated!
-			if (type === Type.String) {
+			if (type === String) {
 				this.value = rs.string(reps);
 			} else {
 				let values = this.value = new Array(reps);
@@ -465,7 +472,7 @@ class Property {
 		if (typeof value === 'string') {
 			buff.string(value);
 		} else {
-			const writer = VALUE_WRITERS[type];
+			const writer = VALUE_WRITERS.get(type);
 			if (Array.isArray(value)) {
 				buff.writeUInt32LE(value.length);
 				for (let entry of value) {
@@ -481,12 +488,23 @@ class Property {
 
 	// ## [Symbol.for('nodejs.util.inspect.custom')](depth, opts, inspect)
 	// Allow custom inspection in Node.js
-	[Symbol.for('nodejs.util.inspect.custom')](depth, opts, nodeInspect) {
+	[Symbol.for('nodejs.util.inspect.custom')]() {
+
+		// The value to be inspected depends on the type.
+		let { type, value } = this;
+		let tf = x => x;
+		switch (type) {
+			case Uint8:
+			case Uint16:
+			case Uint32:
+				tf = x => inspect.hex(x);
+		}
+		value = Array.isArray(value) ? value.map(tf) : tf(value);
 		return {
 			id: inspect.hex(this.id),
-			name: inspect.type(this.name),
-			type: this.type,
-			value: this.value,
+			name: this.name,
+			type: inspect.constructor(type),
+			value,
 		};
 	}
 

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -30,6 +30,12 @@ export function makeEnum(def) {
 }
 export { makeEnum as enum };
 
+// # invertMap(map)
+// Inverts a map.
+export function invertMap(map) {
+	return new Map([...map].map(arr => arr.toReversed()));
+}
+
 // # invert(obj)
 // Inverts an object in-place. Beware of keys that are present as values as 
 // well!
@@ -69,6 +75,13 @@ export const inspect = {
 		return {
 			[kInspect](depth, opts) {
 				return util.styleText('cyan', value);
+			},
+		};
+	},
+	constructor(value) {
+		return {
+			[kInspect]() {
+				return util.styleText('cyan', value.name);
 			},
 		};
 	},


### PR DESCRIPTION
This PR changes the way a type should be specified when creating an exemplar property. Instead of using strings like `Sint8` and `Uint32`, you now have to juse the JavaScript builtins:

```js
new Property({
  id: 0x12345678,
  type: Uint8Array | Uint16Array | Uint32Array | Int32Array | BigInt64Array | Float32Array | Boolean | String,
});
```