### PR TITLE
refactor!: no longer rely on Node.js Buffer

### DIFF
--- a/lib/api/test/create-submenu-button-test.js
+++ b/lib/api/test/create-submenu-button-test.js
@@ -1,10 +1,10 @@
 // # create-submenu-button-test.js
 import { expect } from 'chai';
-import { Buffer } from 'node:buffer';
 import fs from 'node:fs';
 import { resource } from '#test/files.js';
 import { DBPF, FileType } from 'sc4/core';
 import createSubmenuButton from '../create-submenu-button.js';
+import { compareUint8Arrays } from 'uint8array-extras';
 
 describe('#createSubmenuButton()', function() {
 
@@ -42,7 +42,7 @@ describe('#createSubmenuButton()', function() {
 		expect(description.value).to.equal('Open the submenu containing all stadiums');
 
 		let png = clone.find({ type: FileType.PNG }).read();
-		expect(Buffer.compare(png, fs.readFileSync(icon))).to.equal(0);
+		expect(compareUint8Arrays(png, fs.readFileSync(icon))).to.equal(0);
 
 	});
 
@@ -58,7 +58,7 @@ describe('#createSubmenuButton()', function() {
 
 		let clone = new DBPF(dbpf.toBuffer());
 		let png = clone.find({ type: FileType.PNG }).read();
-		expect(Buffer.compare(png, buffer)).to.equal(0);
+		expect(compareUint8Arrays(png, buffer)).to.equal(0);
 
 	});
 

--- a/lib/core/building.js
+++ b/lib/core/building.js
@@ -67,10 +67,7 @@ export default class Building {
 	// ## parse(rs)
 	// Parses the building from a buffer wrapper up in a readable stream.
 	parse(rs) {
-
-		let start = rs.i;
-		let size = rs.dword();
-
+		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
 		this.major = rs.word();
@@ -115,14 +112,7 @@ export default class Building {
 		this.scaffold = rs.float();
 
 		// Make sure the entry was read correctly.
-		let diff = rs.i - start;
-		if (diff !== size) {
-			throw new Error([
-				'Error while reading the entry!',
-				`Size is ${size}, but only read ${diff} bytes!`,
-			].join(' '));
-		}
-
+		rs.assert();
 		return this;
 
 	}

--- a/lib/core/com-serializer-file.js
+++ b/lib/core/com-serializer-file.js
@@ -84,7 +84,7 @@ export default class COMSerializerFile {
 			ws.dword(type);
 			ws.dword(count);
 		}
-		return ws.toBuffer();
+		return ws.toUint8Array();
 
 	}
 

--- a/lib/core/dbpf-entry.js
+++ b/lib/core/dbpf-entry.js
@@ -5,6 +5,7 @@ import FileType from './file-types.js';
 import { decompress } from 'qfs-compression';
 import { getConstructorByType, hasConstructorByType } from './filetype-map.js';
 import Stream from './stream.js';
+import { SmartBuffer } from 'smart-arraybuffer';
 
 // # Entry
 // A class representing an entry in the DBPF file. An entry is a descriptor of 
@@ -323,20 +324,18 @@ const dual = {
 // Reads in a subfile of the DBPF that has an array structure. Typicaly examples 
 // are the lot and prop subfiles.
 function readArrayFile(Constructor, buffer) {
-	let i = 0;
 	let array = [];
-	while (i < buffer.length) {
+	let rs = new Stream(buffer);
+	while (rs.remaining() > 0) {
 
-		// Create a buffer for the specific slice, which is a *view* and 
-		// not a full copy obviously, which is what buffer.slice() returns.
-		let size = buffer.readUInt32LE(i);
-		let slice = buffer.subarray(i, i+size);
-		i += size;
-
-		// Now parse a new child from it and push it in.
-		let rs = new Stream(slice);
+		// IMPORTANT! We read the size, but when reading the buffer to parse the 
+		// entry from, we have to make sure the size is still included! It is an 
+		// integral part of it!
+		let size = rs.dword();
+		rs.readOffset -= 4;
+		let slice = rs.read(size);
 		let child = new Constructor();
-		child.parse(rs);
+		child.parse(new Stream(slice));
 		array.push(child);
 
 	}

--- a/lib/core/dbpf-entry.js
+++ b/lib/core/dbpf-entry.js
@@ -5,7 +5,6 @@ import FileType from './file-types.js';
 import { decompress } from 'qfs-compression';
 import { getConstructorByType, hasConstructorByType } from './filetype-map.js';
 import Stream from './stream.js';
-import { SmartBuffer } from 'smart-arraybuffer';
 
 // # Entry
 // A class representing an entry in the DBPF file. An entry is a descriptor of 

--- a/lib/core/dbpf-entry.js
+++ b/lib/core/dbpf-entry.js
@@ -199,7 +199,7 @@ export default class Entry {
 				for (let file of this.file) {
 					buffer.writeUint8Array(file.toBuffer());
 				}
-				return buffer.toBuffer();
+				return buffer.toUint8Array();
 			} else {
 				return this.file.toBuffer();
 			}

--- a/lib/core/dbpf-entry.js
+++ b/lib/core/dbpf-entry.js
@@ -330,8 +330,7 @@ function readArrayFile(Constructor, buffer) {
 		// IMPORTANT! We read the size, but when reading the buffer to parse the 
 		// entry from, we have to make sure the size is still included! It is an 
 		// integral part of it!
-		let size = rs.dword();
-		rs.readOffset -= 4;
+		let size = rs.dword(rs.readOffset);
 		let slice = rs.read(size);
 		let child = new Constructor();
 		child.parse(new Stream(slice));

--- a/lib/core/dbpf-entry.js
+++ b/lib/core/dbpf-entry.js
@@ -1,7 +1,7 @@
 // # dbpf-entry.js
 import { tgi, inspect, duplicateAsync } from 'sc4/utils';
+import WriteBuffer from './write-buffer.js';
 import FileType from './file-types.js';
-import { Buffer } from 'buffer';
 import { decompress } from 'qfs-compression';
 import { getConstructorByType, hasConstructorByType } from './filetype-map.js';
 import Stream from './stream.js';
@@ -195,11 +195,11 @@ export default class Entry {
 		// level of abstraction.
 		if (this.file) {
 			if (this.isArrayType) {
-				let parts = [];
+				let buffer = new WriteBuffer();
 				for (let file of this.file) {
-					parts.push(file.toBuffer());
+					buffer.writeUint8Array(file.toBuffer());
 				}
-				return Buffer.concat(parts);
+				return buffer.toBuffer();
 			} else {
 				return this.file.toBuffer();
 			}

--- a/lib/core/dbpf-header.js
+++ b/lib/core/dbpf-header.js
@@ -78,7 +78,7 @@ export default class Header {
 		buffer.uint32(0);
 		buffer.zeroes(4);
 		buffer.zeroes(24);
-		return buffer.toBuffer();
+		return buffer.toUint8Array();
 
 	}
 

--- a/lib/core/dbpf.js
+++ b/lib/core/dbpf.js
@@ -1,5 +1,4 @@
 // # dbpf.js
-import { Buffer } from 'buffer';
 import { compress } from 'qfs-compression';
 import { isUint8Array, uint8ArrayToHex } from 'uint8array-extras';
 import { register } from './filetype-map.js';
@@ -148,7 +147,7 @@ export default class DBPF {
 		// If we don't have a buffer, but we do have a file path, then we read 
 		// that specific part.
 		if (this.file) {
-			let buffer = Buffer.allocUnsafe(length);
+			let buffer = new Uint8Array(length);
 			let fd = fs.openSync(this.file);
 			fs.readSync(fd, buffer, 0, length, offset);
 			fs.closeSync(fd);
@@ -167,7 +166,7 @@ export default class DBPF {
 	async readBytesAsync(offset, length) {
 		if (this.buffer) return this.buffer.subarray(offset, offset+length);
 		else if (this.file) {
-			let buffer = Buffer.allocUnsafe(length);
+			let buffer = new Uint8Array(length);
 			let fh = await fs.promises.open(this.file);
 			await fh.read(buffer, 0, length, offset);
 			await fh.close();

--- a/lib/core/dbpf.js
+++ b/lib/core/dbpf.js
@@ -1,7 +1,7 @@
 // # dbpf.js
 import { Buffer } from 'buffer';
 import { compress } from 'qfs-compression';
-import { isUint8Array } from 'uint8array-extras';
+import { isUint8Array, uint8ArrayToHex } from 'uint8array-extras';
 import { register } from './filetype-map.js';
 import Header from './dbpf-header.js';
 import Entry from './dbpf-entry.js';
@@ -11,6 +11,7 @@ import Stream from './stream.js';
 import crc32 from './crc.js';
 import { cClass, FileType } from './enums.js';
 import { fs, TGIIndex, duplicateAsync } from 'sc4/utils';
+import { SmartBuffer } from 'smart-arraybuffer';
 
 // # DBPF()
 // A class that represents a DBPF file. A DBPF file is basically just a custom 
@@ -328,7 +329,11 @@ export default class DBPF {
 		header.writeUInt32LE(tableBuffer.byteLength, 44);
 
 		// Concatenate everything and report.
-		return Buffer.concat(chunks);
+		const writer = new SmartBuffer();
+		for (let chunk of chunks) {
+			writer.writeBuffer(chunk);
+		}
+		return writer.toBuffer();
 
 	}
 
@@ -448,18 +453,20 @@ export default class DBPF {
 		// Create a buffer that we'll use to convert numbers to hex.
 		let out = new Array(refs.length);
 		let strings = new Array(refs.length);
-		let help = Buffer.alloc(4);
+		let help = new Uint8Array(4);
+		let view = new DataView(help.buffer);
 		for (let i = 0; i < out.length; i++) {
 			out[i] = [];
 			let ref = refs[i];
+			view.setUint32(0, ref, true);
 			help.writeUInt32LE(ref);
-			strings[i] = help.toString('hex');
+			strings[i] = uint8ArrayToHex(help);
 		}
 
 		// Loop all entries as outer loop. This way we only have to calculate 
 		// the hex string once. Speeds things up a little.
 		for (let entry of this) {
-			let raw = entry.decompress().toString('hex');
+			let raw = uint8ArrayToHex(entry.decompress());
 			for (let i = 0; i < refs.length; i++) {
 				let hex = strings[i];
 				let index = raw.indexOf(hex);

--- a/lib/core/dbpf.js
+++ b/lib/core/dbpf.js
@@ -1,6 +1,6 @@
 // # dbpf.js
 import { compress } from 'qfs-compression';
-import { isUint8Array, uint8ArrayToHex } from 'uint8array-extras';
+import { concatUint8Arrays, isUint8Array, uint8ArrayToHex } from 'uint8array-extras';
 import { register } from './filetype-map.js';
 import Header from './dbpf-header.js';
 import Entry from './dbpf-entry.js';
@@ -219,12 +219,12 @@ export default class DBPF {
 		// return fs.promises.writeFile(opts.file, buff);
 	}
 
-	// ## toBuffer(opts)
-	// Serializes the DBPF to a buffer. Note that we can't use a streamed api 
-	// here because the location of the index is dependent on the size of all 
-	// entries, but the location of the index is written in the header. Hence 
-	// not possible.
-	toBuffer(opts) {
+	// ## toBuffer()
+	// Serializes the DBPF to a *Uint8Array*. Note that this is called 
+	// `.toBuffer()` for legacy purposes, but the goal is to rename it 
+	// eventually to `toUint8Array()` because we are no longer requiring Node.js 
+	// buffers.
+	toBuffer() {
 
 		// Generate the header buffer.
 		let header = this.header.toBuffer();
@@ -321,7 +321,7 @@ export default class DBPF {
 
 		// Now add the indexTable buffer as well & write its position & count 
 		// into the header.
-		let tableBuffer = table.toBuffer();
+		let tableBuffer = table.toUint8Array();
 		chunks.push(tableBuffer);
 		let writer = SmartBuffer.fromBuffer(header);
 		writer.writeUInt32LE(list.length, 36);
@@ -329,11 +329,7 @@ export default class DBPF {
 		writer.writeUInt32LE(tableBuffer.byteLength, 44);
 
 		// Concatenate everything and report.
-		writer = new SmartBuffer();
-		for (let chunk of chunks) {
-			writer.writeBuffer(chunk);
-		}
-		return writer.toBuffer();
+		return concatUint8Arrays(chunks);
 
 	}
 

--- a/lib/core/dbpf.js
+++ b/lib/core/dbpf.js
@@ -323,12 +323,13 @@ export default class DBPF {
 		// into the header.
 		let tableBuffer = table.toBuffer();
 		chunks.push(tableBuffer);
-		header.writeUInt32LE(list.length, 36);
-		header.writeUInt32LE(offset, 40);
-		header.writeUInt32LE(tableBuffer.byteLength, 44);
+		let writer = SmartBuffer.fromBuffer(header);
+		writer.writeUInt32LE(list.length, 36);
+		writer.writeUInt32LE(offset, 40);
+		writer.writeUInt32LE(tableBuffer.byteLength, 44);
 
 		// Concatenate everything and report.
-		const writer = new SmartBuffer();
+		writer = new SmartBuffer();
 		for (let chunk of chunks) {
 			writer.writeBuffer(chunk);
 		}

--- a/lib/core/dir.js
+++ b/lib/core/dir.js
@@ -46,7 +46,7 @@ export default class DIR extends Array {
 			ws.uint32(row.size);
 			if (byteLength === 20) ws.uint32(0);
 		}
-		return ws.toBuffer();
+		return ws.toUint8Array();
 	}
 
 }

--- a/lib/core/dir.js
+++ b/lib/core/dir.js
@@ -22,7 +22,7 @@ export default class DIR extends Array {
 
 		// Reset our length and then read in the entire DIR record.
 		this.length = 0;
-		while (!rs.eof(entry.fileSize)) {
+		while (rs.remaining() > 0) {
 			let type = rs.uint32();
 			let group = rs.uint32();
 			let instance = rs.uint32();

--- a/lib/core/exemplar.js
+++ b/lib/core/exemplar.js
@@ -479,7 +479,7 @@ class Property {
 				writer(buff, value);
 			}
 		}
-		return buff.toBuffer();
+		return buff.toUint8Array();
 
 	}
 

--- a/lib/core/exemplar.js
+++ b/lib/core/exemplar.js
@@ -327,7 +327,7 @@ export class Exemplar {
 		// Write all properties to the buffer as well. Note that writing 
 		// arrays is handled automatically.
 		buffer.array(props);
-		return buffer.toBuffer();
+		return buffer.toUint8Array();
 
 	}
 

--- a/lib/core/exemplar.js
+++ b/lib/core/exemplar.js
@@ -1,6 +1,6 @@
 // # exemplar.js
-import { Buffer } from 'buffer';
-import { isUint8Array } from 'uint8array-extras';
+import { isUint8Array, hexToUint8Array } from 'uint8array-extras';
+import { SmartBuffer } from 'smart-arraybuffer';
 import Stream from './stream.js';
 import WriteBuffer from './write-buffer.js';
 import NAMES from './exemplar-props.js';
@@ -301,10 +301,8 @@ export class Exemplar {
 
 		// Write away the id, but only use the binary format for now, so 
 		// ensure the 4th byte is the character B.
-		let header = Buffer.allocUnsafe(this.id.length);
-		header.write(this.id);
-		header.write('B', 3);
-		buffer.write(header);
+		buffer.writeString(this.id);
+		buffer.writeString('B', 3);
 		for (let tgi of this.parent) {
 			buffer.writeUInt32LE(tgi);
 		}
@@ -675,20 +673,14 @@ function readFloat(type) {
 function readBigInt() {
 	let hex = readHexString();
 	if (hex === undefined) return undefined;
-	let buff = Buffer.from(hex.slice(2), 'hex');
-	if (buff.readInt64BE) {
-		return buff.readBigInt64BE(0);
-	} else {
-		buff.reverse();
-		return buff.readBigInt64LE(0);
-	}
+	return Number(hex);
 }
 
 function readInt32() {
 	let hex = readHexString();
 	if (hex === undefined) return undefined;
-	let buff = Buffer.from(hex.slice(2), 'hex');
-	return buff.readInt32BE(0);
+	if (typeof BigInt === 'undefined') return +hex;
+	return BigInt(hex);
 }
 
 const boolRegex = /(true|false)/i;

--- a/lib/core/exemplar.js
+++ b/lib/core/exemplar.js
@@ -1,6 +1,5 @@
 // # exemplar.js
-import { isUint8Array, hexToUint8Array } from 'uint8array-extras';
-import { SmartBuffer } from 'smart-arraybuffer';
+import { isUint8Array } from 'uint8array-extras';
 import Stream from './stream.js';
 import WriteBuffer from './write-buffer.js';
 import NAMES from './exemplar-props.js';

--- a/lib/core/item-index.js
+++ b/lib/core/item-index.js
@@ -1,5 +1,4 @@
 // # item-index-file.js
-import Stream from './stream.js';
 import WriteBuffer from './write-buffer.js';
 import Pointer from './pointer.js';
 import { FileType } from './enums.js';

--- a/lib/core/item-index.js
+++ b/lib/core/item-index.js
@@ -102,12 +102,9 @@ export default class ItemIndex extends Array {
 		}
 	}
 
-	// ## parse(buff)
-	parse(buff) {
-
-		let rs = new Stream(buff);
-		let start = rs.i;
-		let size = rs.dword();
+	// ## parse(rs)
+	parse(rs) {
+		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
 		this.major = rs.word();
@@ -135,15 +132,7 @@ export default class ItemIndex extends Array {
 		}
 
 		// Check if we've read everything correctly.
-		let diff = rs.i - start;
-		if (diff !== size) {
-			console.warn([
-				'Error when reading Item Index File',
-				`Expected ${size} bytes, but read ${diff}!`,
-			]);
-			rs.jump(start + size);
-		}
-
+		rs.assert();
 		return this;
 
 	}

--- a/lib/core/lot-base-texture.js
+++ b/lib/core/lot-base-texture.js
@@ -197,7 +197,7 @@ class Texture {
 		ws.byte(this.alpha);
 		ws.byte(this.u6);
 		ws.byte(this.u7);
-		return ws.toBuffer();
+		return ws.toUint8Array();
 	}
 
 }

--- a/lib/core/lot-base-texture.js
+++ b/lib/core/lot-base-texture.js
@@ -66,9 +66,7 @@ export default class LotBaseTexture {
 
 	// ## parse(rs)
 	parse(rs) {
-
-		let start = rs.i;
-		let size = rs.dword();
+		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
 		this.major = rs.word();
@@ -105,11 +103,7 @@ export default class LotBaseTexture {
 		}
 
 		// Check that we've read everything.
-		let diff = rs.i - start;
-		if (diff !== size) {
-			console.warn(`Size was ${size}, but read ${diff} bytes!`);
-			rs.jump(start + size);
-		}
+		rs.assert();
 
 	}
 

--- a/lib/core/lot-developer-file.js
+++ b/lib/core/lot-developer-file.js
@@ -21,10 +21,10 @@ export default class LotDeveloperFile {
 		this.u4 = 0x0000;
 	}
 
-	// ## parse(buff)
-	parse(buff) {
-		let rs = new Stream(buff);
-		let size = rs.dword();
+	// ## parse(buffer)
+	parse(buffer) {
+		let rs = new Stream(buffer);
+		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
 		this.major = rs.word();
@@ -42,17 +42,8 @@ export default class LotDeveloperFile {
 		// Read in the rest.
 		this.u3 = rs.dword();
 		this.u4 = rs.word();
-
-		// Check if we read everything correctly.
-		if (size !== rs.i) {
-			console.warn([
-				'Error when reading LotDeveloper Subfile!',
-				`Expected ${size} bytes, but read ${rs.i}.`,
-			].join(' '));
-		}
-
+		rs.assert();
 		return this;
-
 	}
 
 	// ## clear()

--- a/lib/core/lot.js
+++ b/lib/core/lot.js
@@ -1,5 +1,4 @@
 // # lot-file.js
-import { Buffer } from 'buffer';
 import WriteBuffer from './write-buffer.js';
 import { FileType, ZoneType, DemandSourceIndex } from './enums.js';
 
@@ -343,7 +342,7 @@ export default class Lot {
 
 		// Check if there's a commute buffer. Include it as is. We don't allow 
 		// modifying the commutes for now.
-		let commuteBuffer = this.commuteBuffer || Buffer.alloc(0);
+		let commuteBuffer = this.commuteBuffer || new Uint8Array(0);
 		ws.write(commuteBuffer);
 
 		// A last buffer for the debug symbol.

--- a/lib/core/lot.js
+++ b/lib/core/lot.js
@@ -180,9 +180,7 @@ export default class Lot {
 	// ## parse(rs)
 	// Parses the load from a buffer wrapped up in a readable stream.
 	parse(rs) {
-
-		let start = rs.i;
-		let size = rs.dword();
+		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
 		this.major = rs.word();
@@ -254,9 +252,7 @@ export default class Lot {
 		// For now we're not parsing the commutes. Structure is still a bit 
 		// unclear, we'll do this later. Simply store the raw buffer.
 		if (count > 0) {
-			let offset = rs.i - start;
-			let byteLength = size - offset - 1;
-			this.commuteBuffer = rs.read(byteLength);
+			this.commuteBuffer = rs.read(rs.remaining()-1);
 		}
 
 		// for (let i = 0; i < count; i++) {
@@ -270,21 +266,7 @@ export default class Lot {
 		this.debug = rs.byte();
 
 		// Make sure the entry was read correctly.
-		let diff = rs.i - start;
-		if (diff !== size) {
-			// try {
-			throw new Error([
-				'Error while reading the entry!',
-				`Size is ${size}, but only ${diff} bytes were read!`,
-			].join(' '));
-			// } catch (e) {
-
-			// 	// Jump to the end.
-			// 	// rs.jump(start + size);
-			// 	throw e;
-
-			// }
-		}
+		rs.assert();
 
 		// Done!
 		return this;

--- a/lib/core/ltext.js
+++ b/lib/core/ltext.js
@@ -38,7 +38,7 @@ export default class LText {
 		for (let char of this.value) {
 			ws.word(char.charCodeAt(0));
 		}
-		return ws.toBuffer();
+		return ws.toUint8Array();
 	}
 
 }

--- a/lib/core/network-index.js
+++ b/lib/core/network-index.js
@@ -1,5 +1,4 @@
 // # network-index.js
-import { Buffer } from 'buffer';
 import Stream from './stream.js';
 import WriteBuffer from './write-buffer.js';
 import Unknown from './unknown.js';
@@ -109,10 +108,10 @@ class NetworkIndexTile {
 		u.dword(0x00000000);
 		u.dword(0x00000000);
 		this.reps = [
-			Buffer.alloc(12),
-			Buffer.alloc(12),
-			Buffer.alloc(12),
-			Buffer.alloc(12),
+			new Uint8Array(12),
+			new Uint8Array(12),
+			new Uint8Array(12),
+			new Uint8Array(12),
 		];
 		u.dword(0x00000000);
 		this.reps2 = [];

--- a/lib/core/prop.js
+++ b/lib/core/prop.js
@@ -43,9 +43,7 @@ export default class Prop {
 	// ## parse(rs)
 	// Parses the prop from the given readable stream.
 	parse(rs) {
-		
-		let start = rs.i;
-		let size = rs.dword();
+		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
 		this.major = rs.word();
@@ -99,16 +97,7 @@ export default class Prop {
 		this.lotType = rs.byte();
 		this.OID = rs.dword();
 		this.condition = rs.byte();
-
-		let diff = rs.i - start;
-		if (diff !== size) {
-			console.warn([
-				'Error while reading a prop!',
-				`Size is ${size}, but read ${diff} bytes!`,
-				'This may indicate a prop-poxed city!',
-			].join(' '));
-			rs.jump(start + size);
-		}
+		rs.assert();
 
 		// Done.
 		return this;

--- a/lib/core/sgprop.js
+++ b/lib/core/sgprop.js
@@ -88,7 +88,7 @@ export default class SGProp {
 		}
 
 		// Don't forget to convert the smart buffer into a *normal* buffer!
-		return ws.toBuffer();
+		return ws.toUint8Array();
 
 	}
 

--- a/lib/core/sgprop.js
+++ b/lib/core/sgprop.js
@@ -101,7 +101,7 @@ readers[0x03] = rs => rs.uint32();
 readers[0x07] = rs => rs.int32();
 readers[0x08] = rs => rs.bigint64();
 readers[0x09] = rs => rs.float();
-readers[0x0b] = rs => Boolean(rs.byte());
+readers[0x0b] = rs => rs.bool();
 
 const writers = new Array(0x0c).fill(x => x);
 writers[0x01] = (ws, value) => ws.uint8(value);

--- a/lib/core/sim-grid-file.js
+++ b/lib/core/sim-grid-file.js
@@ -61,8 +61,7 @@ class SimGrid {
 
 	// ## parse(rs)
 	parse(rs) {
-		let start = rs.i;
-		let size = rs.dword();
+		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
 		this.major = rs.word();
@@ -93,13 +92,7 @@ class SimGrid {
 		}
 
 		// Ensure that we've read everything correctly.
-		let diff = rs.i - start;
-		if (diff !== size) {
-			console.warn([
-				'Error while reading SimGrid!',
-				`Expected ${size} bytes, but read ${diff}!`,
-			]);
-		}
+		rs.assert();
 
 		// Done! Easy data access is available by calling createProxy(). Using 
 		// this it's possible to access the data as if it were a 

--- a/lib/core/stream.js
+++ b/lib/core/stream.js
@@ -60,27 +60,27 @@ export default class Stream extends SmartBuffer {
 		return this.readBuffer();
 	}
 
-	int8() { return this.readInt8(); }
-	int16() { return this.readInt16LE(); }
-	int32() { return this.readInt32LE(); }
-	bigint64() { return this.readBigInt64LE(); }
-	float() { return this.readFloatLE(); }
-	double() { return this.readDoubleLE(); }
-	uint8() { return this.readUInt8(); }
-	uint16() { return this.readUInt16LE(); }
-	uint32() { return this.readUInt32LE(); }
+	int8(offset) { return this.readInt8(offset); }
+	int16(offset) { return this.readInt16LE(offset); }
+	int32(offset) { return this.readInt32LE(offset); }
+	bigint64(offset) { return this.readBigInt64LE(offset); }
+	float(offset) { return this.readFloatLE(offset); }
+	double(offset) { return this.readDoubleLE(offset); }
+	uint8(offset) { return this.readUInt8(offset); }
+	uint16(offset) { return this.readUInt16LE(offset); }
+	uint32(offset) { return this.readUInt32LE(offset); }
 
 	// Some aliases.
-	byte() { return this.uint8(); }
-	word() { return this.uint16(); }
-	dword() { return this.uint32(); }
-	qword() { return this.bigint64(); }
-	bool() { return Boolean(this.uint8()); }
+	byte(offset) { return this.uint8(offset); }
+	word(offset) { return this.uint16(offset); }
+	dword(offset) { return this.uint32(offset); }
+	qword(offset) { return this.bigint64(offset); }
+	bool(offset) { return Boolean(this.uint8(offset)); }
 
 	// ## size()
 	// The size of a record is simply a dword, but it makes it clearer that 
 	// we're reading in a size, so we use an alias.
-	size() { return this.dword(); }
+	size(offset) { return this.dword(offset); }
 
 	// Helper function for reading a pointer. Those are given as [pointer, 
 	// Type ID]. Note that if no address was given, we return "null" (i.e. a 

--- a/lib/core/stream.js
+++ b/lib/core/stream.js
@@ -22,13 +22,6 @@ export default class Stream extends SmartBuffer {
 		}
 	}
 
-	// ## get i()
-	// Some files still rely on the "i" property being present. Hence we still 
-	// support this for now, but we should deprecate it.
-	get i() {
-		return this.readOffset;
-	}
-
 	// ## skip(n = 1)
 	// Skips n bytes.
 	skip(n = 1) {
@@ -149,7 +142,8 @@ export default class Stream extends SmartBuffer {
 	// an error if it's not the case. Useful for checking if a decoded 
 	// structure is valid for all kinds of cities.
 	assert() {
-		if (this.remaining() > 0) {
+		let n = this.remaining();
+		if (n > 0) {
 			throw new Error(`Stream has not been fully consumed yet! ${n} bytes remaining!`);
 		}
 	}

--- a/lib/core/stream.js
+++ b/lib/core/stream.js
@@ -25,9 +25,22 @@ export default class Stream {
 		}
 	}
 
+	get readOffset() {
+		return this.i;
+	}
+
+	set readOffset(i) {
+		this.i = i;
+	}
+
 	// ## eof(size)
 	eof(size = this.buffer.byteLength) {
 		return !(this.i < size);
+	}
+
+	// ## remaining()
+	remaining() {
+		return this.buffer.byteLength - this.i;
 	}
 
 	// ## skip(n=1)

--- a/lib/core/stream.js
+++ b/lib/core/stream.js
@@ -1,5 +1,5 @@
 // # stream.js
-import { Buffer } from 'buffer';
+import { SmartBuffer } from 'smart-arraybuffer';
 import Pointer from './pointer.js';
 import SGProp from './sgprop.js';
 import Color from './color.js';
@@ -8,75 +8,47 @@ import Vertex from './vertex.js';
 // # Stream
 // Helper class that provides some methods for reading from a buffer 
 // sequentially, maintaining buffer state.
-export default class Stream {
+export default class Stream extends SmartBuffer {
 
-	// ## constructor(bufferOrStream)
-	// Constructs a new read stream, either from a buffer, or from an existing 
-	// stream.
-	constructor(bufferOrStream) {
-		if (bufferOrStream instanceof Stream) {
-			this.buffer = bufferOrStream.buffer;
-			this.raw = bufferOrStream.raw;
-			this.i = bufferOrStream.i;
+	// ## constructor(opts)
+	constructor(opts) {
+		if (opts instanceof Uint8Array || opts instanceof ArrayBuffer) {
+			super({ buff: opts });
+		} else if (opts instanceof Stream) {
+			super({ buff: opts.internalUint8Array });
+			this.readOffset = opts.readOffset;
 		} else {
-			this.buffer = bufferOrStream;
-			this.raw = bufferOrStream.buffer;
-			this.i = 0;
+			super(opts);
 		}
 	}
 
-	get readOffset() {
-		return this.i;
+	// ## get i()
+	// Some files still rely on the "i" property being present. Hence we still 
+	// support this for now, but we should deprecate it.
+	get i() {
+		return this.readOffset;
 	}
 
-	set readOffset(i) {
-		this.i = i;
+	// ## skip(n = 1)
+	// Skips n bytes.
+	skip(n = 1) {
+		this.readOffset += n;
 	}
 
-	// ## eof(size)
-	eof(size = this.buffer.byteLength) {
-		return !(this.i < size);
-	}
-
-	// ## remaining()
-	remaining() {
-		return this.buffer.byteLength - this.i;
-	}
-
-	// ## skip(n=1)
-	// Skips "n" bytes, but returns the position of i as it was before!
-	skip(n=1) {
-		let i = this.i;
-		this.i += n;
-		return i;
-	}
-
-	// ## jump(offset)
-	// Jumps to the given offset.
-	jump(offset) {
-		this.i = offset;
-		return this;
+	// ## read()
+	read(length) {
+		return this.readUint8Array(length);
 	}
 
 	// ## string(length)
 	// Reads a string with the given length, as utf8. Note: if no length is 
 	// given, we assume we have to read the length first as a dword.
 	string(length = this.dword()) {
-		let start = this.skip(length);
-		return this.buffer.toString('utf8', start, this.i);
-	}
-
-	// ## read(n=1)
-	read(n=1) {
-		let offset = this.buffer.offset;
-		return Buffer.from(this.raw, offset+this.skip(n), n);
-	}
-
-	// ## slice(n=1)
-	// Similar to read, but returns a new buffer instead of just a view on top 
-	// of the underlying buffer.
-	slice(n=1) {
-		return this.buffer.slice(this.skip(n), this.i);
+		if (length === Infinity || !length) {
+			return this.readString();
+		} else {
+			return this.readString(length);
+		}
 	}
 
 	// ## chunk()
@@ -85,26 +57,25 @@ export default class Stream {
 	// "SIZE CRC MEM ...". Note that we return a view on top of the underlying 
 	// buffer, we don't copy it!
 	chunk() {
-		let size = this.buffer.readUInt32LE(this.i);
+		let size = this.readUInt32LE(this.readOffset);
 		return this.read(size);
 	}
 
 	// ## rest()
 	// Helper function for reading the rest of the buffer - as a slice.
 	rest() {
-		return this.read(this.buffer.length - this.i);
+		return this.readBuffer();
 	}
 
-	peek() { return this.buffer[this.i]; }
-	int8() { return this.buffer.readInt8(this.skip(1)); }
-	int16() { return this.buffer.readInt16LE(this.skip(2)); }
-	int32() { return this.buffer.readInt32LE(this.skip(4)); }
-	bigint64() { return this.buffer.readBigInt64LE(this.skip(8)); }
-	float() { return this.buffer.readFloatLE(this.skip(4)); }
-	double() { return this.buffer.readDoubleLE(this.skip(8)); }
-	uint8() { return this.buffer.readUInt8(this.skip(1)); }
-	uint16() { return this.buffer.readUInt16LE(this.skip(2)); }
-	uint32() { return this.buffer.readUInt32LE(this.skip(4)); }
+	int8() { return this.readInt8(); }
+	int16() { return this.readInt16LE(); }
+	int32() { return this.readInt32LE(); }
+	bigint64() { return this.readBigInt64LE(); }
+	float() { return this.readFloatLE(); }
+	double() { return this.readDoubleLE(); }
+	uint8() { return this.readUInt8(); }
+	uint16() { return this.readUInt16LE(); }
+	uint32() { return this.readUInt32LE(); }
 
 	// Some aliases.
 	byte() { return this.uint8(); }
@@ -170,7 +141,7 @@ export default class Stream {
 	// ## sgprops()
 	// Reads in an array of sgprops.
 	sgprops() {
-		return this.array(rs => new SGProp().parse(rs));
+		return this.array(() => new SGProp().parse(this));
 	}
 
 	// ## assert()
@@ -178,9 +149,7 @@ export default class Stream {
 	// an error if it's not the case. Useful for checking if a decoded 
 	// structure is valid for all kinds of cities.
 	assert() {
-		let { i, buffer } = this;
-		if (i !== buffer.length) {
-			let n = buffer.length - i;
+		if (this.remaining() > 0) {
 			throw new Error(`Stream has not been fully consumed yet! ${n} bytes remaining!`);
 		}
 	}

--- a/lib/core/terrain-map.js
+++ b/lib/core/terrain-map.js
@@ -60,7 +60,7 @@ export default class TerrainMap extends Array {
 
 		// Determine the size based on the buffer length alone.
 		let rs = new Stream(bufferOrStream);
-		this.xSize = this.zSize = Math.sqrt((rs.buffer.length-2)/4);
+		this.xSize = this.zSize = Math.sqrt((rs.internalUint8Array.length-2)/4);
 		this.fill();
 
 		// Now actually read in all the values, in their natural order. This 

--- a/lib/core/terrain-map.js
+++ b/lib/core/terrain-map.js
@@ -82,7 +82,7 @@ export default class TerrainMap extends Array {
 		for (let i = 0; i < this.raw.length; i++) {
 			ws.float(this.raw[i]);
 		}
-		return ws.toBuffer();
+		return ws.toUint8Array();
 	}
 
 	// ## get(i, j)

--- a/lib/core/test/com-serializer-file-test.js
+++ b/lib/core/test/com-serializer-file-test.js
@@ -1,5 +1,6 @@
 // # com-serializer-file-test.js
 import { expect } from 'chai';
+import { compareUint8Arrays } from 'uint8array-extras';
 import fs from 'node:fs';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
@@ -22,7 +23,7 @@ describe('The COM serializer file', function() {
 		// Serialize again, buffer should look the same.
 		let check = entry.buffer;
 		let buff = com.toBuffer();
-		expect(buff.toString('hex')).to.equal(check.toString('hex'));
+		expect(compareUint8Arrays(buff, check)).to.equal(0);
 
 	});
 

--- a/lib/core/test/com-serializer-file-test.js
+++ b/lib/core/test/com-serializer-file-test.js
@@ -1,7 +1,7 @@
 // # com-serializer-file-test.js
 import { expect } from 'chai';
 import { compareUint8Arrays } from 'uint8array-extras';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
 

--- a/lib/core/test/crc-test.js
+++ b/lib/core/test/crc-test.js
@@ -1,17 +1,17 @@
 // # crc-test.js
-import { Buffer } from 'node:buffer';
 import { expect } from 'chai';
+import { SmartBuffer } from 'smart-arraybuffer';
 import crc32 from '../crc.js';
 
 describe('The CRC32 checksum', function() {
 
 	it('calculates crc checksums correctly', function() {
 
-		let buff = Buffer.alloc(8);
+		let buff = SmartBuffer.fromBuffer(new Uint8Array());
 		buff.writeFloatLE(Math.PI, 0);
 		buff.writeFloatLE(Math.E, 4);
 
-		let crc = crc32(buff);
+		let crc = crc32(buff.toUint8Array());
 		expect(crc).to.equal(0x55ac179c);
 
 	});

--- a/lib/core/test/dbpf-test.js
+++ b/lib/core/test/dbpf-test.js
@@ -1,7 +1,7 @@
 // # dbpf-test.js
 import { expect } from 'chai';
 import fs from 'node:fs';
-import { compareUint8Arrays } from 'uint8array-extras';
+import { compareUint8Arrays, uint8ArrayToString } from 'uint8array-extras';
 import { resource, output } from '#test/files.js';
 
 import {
@@ -13,6 +13,7 @@ import {
 	cClass,
 } from 'sc4/core';
 import crc32 from '../crc.js';
+import { SmartBuffer } from 'smart-arraybuffer';
 
 describe('A DBPF file', function() {
 
@@ -128,7 +129,7 @@ describe('A DBPF file', function() {
 		// Serialize the DBPF into a buffer and immediately parse again so 
 		// that we can compare.
 		let buff = dbpf.toBuffer();
-		expect(buff.subarray(0, 4).toString()).to.equal('DBPF');
+		expect(uint8ArrayToString(buff.subarray(0, 4))).to.equal('DBPF');
 		let my = new DBPF(buff);
 		expect(my).to.have.length(dbpf.length);
 		
@@ -226,41 +227,6 @@ describe('A DBPF file', function() {
 
 });
 
-describe('An exemplar file', function() {
-
-	it('should serialize to a buffer correctly', function() {
-
-		// Read an exemplar from a sample dbpf first.
-		let file = resource('cement.sc4lot');
-		let buff = fs.readFileSync(file);
-		let dbpf = new DBPF(buff);
-
-		let exemplars = dbpf.exemplars;
-		let raw = exemplars.map(entry => entry.decompress());
-
-		for (let i = 0; i < exemplars.length; i++) {
-			let entry = exemplars[i];
-			let exemplar = entry.read();
-			let bin = exemplar.toBuffer().toString('hex');
-			let check = raw[i].toString('hex');
-			expect(bin).to.equal(check);
-		}
-
-	});
-
-	it('should read textual exemplars', function() {
-
-		let file = resource('quotes.sc4desc');
-		let buff = fs.readFileSync(file);
-		let dbpf = new DBPF(buff);
-
-		let entry = dbpf.exemplars[0];
-		entry.read();
-
-	});
-
-});
-
 describe('A lot subfile', function() {
 
 	it('should be parsed & serialized correctly', function() {
@@ -278,7 +244,7 @@ describe('A lot subfile', function() {
 			// Note: toBuffer() updates the crc, so make sure to grab the old 
 			// one!
 			let crc = lot.crc;
-			let buff = lot.toBuffer();
+			let buff = SmartBuffer.fromBuffer(lot.toBuffer());
 			expect(buff.readUInt32LE(4)).to.equal(crc);
 
 		}
@@ -430,7 +396,7 @@ describe('A building subfile', function() {
 			// Note: toBuffer() updates the crc, so make sure to grab the old 
 			// one!
 			let crc = building.crc;
-			let buff = building.toBuffer();
+			let buff = SmartBuffer.fromBuffer(building.toBuffer());
 			expect(buff.readUInt32LE(4)).to.equal(crc);
 
 		}
@@ -439,7 +405,7 @@ describe('A building subfile', function() {
 		// the same buffer.
 		let source = entry.decompress();
 		let check = entry.toBuffer();
-		expect(source.toString('hex')).to.equal(check.toString('hex'));
+		expect(compareUint8Arrays(source, check)).to.equal(0);
 
 	});
 
@@ -461,7 +427,7 @@ describe('A prop subfile', function() {
 			// Note: toBuffer() updates the crc, so make sure to grab the old
 			// one!
 			let crc = prop.crc;
-			let buff = prop.toBuffer();
+			let buff = SmartBuffer.fromBuffer(prop.toBuffer());
 			expect(buff.readUInt32LE(4)).to.equal(crc);
 
 		}
@@ -497,7 +463,7 @@ describe('The flora subfile', function() {
 		for (let item of flora) {
 
 			let crc = item.crc;
-			let buff = item.toBuffer();
+			let buff = SmartBuffer.fromBuffer(item.toBuffer());
 			expect(buff.readUInt32LE(4)).to.equal(crc);
 
 		}
@@ -525,7 +491,7 @@ describe('The network subfile', function() {
 		// should still match.
 		for (let tile of network) {
 			let crc = tile.crc;
-			let buff = tile.toBuffer();
+			let buff = SmartBuffer.fromBuffer(tile.toBuffer());
 			expect(buff.readUInt32LE(4)).to.equal(crc);
 		}
 

--- a/lib/core/test/dbpf-test.js
+++ b/lib/core/test/dbpf-test.js
@@ -1,6 +1,6 @@
 // # dbpf-test.js
 import { expect } from 'chai';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { compareUint8Arrays, uint8ArrayToString } from 'uint8array-extras';
 import { resource, output } from '#test/files.js';
 
@@ -153,16 +153,16 @@ describe('A DBPF file', function() {
 
 		let all = [];
 		for (let entry of dbpf) {
-			let buff = entry.decompress();
-			let size = buff.readUInt32LE();
+			let buff = SmartBuffer.fromBuffer(entry.decompress());
+			let size = buff.readUInt32LE(0);
 
 			// If what we're interpreting as size is larger than the buffer, 
 			// it's impossible that this has the structure size crc mem!
-			if (size > buff.byteLength) continue;
+			if (size > buff.length) continue;
 
 			// Calculate the checksum. If it matches the second value, then we 
 			// have something of the structure "size crc mem".
-			let crc = crc32(buff, 8);
+			let crc = crc32(entry.decompress(), 8);
 			if (crc === buff.readUInt32LE(4)) {
 				let type = entry.type;
 				let name = cClass[type].replace(/^cSC4/, '');

--- a/lib/core/test/dbpf-test.js
+++ b/lib/core/test/dbpf-test.js
@@ -1,7 +1,7 @@
 // # dbpf-test.js
 import { expect } from 'chai';
 import fs from 'node:fs';
-import { Buffer } from 'buffer';
+import { compareUint8Arrays } from 'uint8array-extras';
 import { resource, output } from '#test/files.js';
 
 import {
@@ -207,21 +207,6 @@ describe('A DBPF file', function() {
 
 	describe('#add()', function() {
 
-		it('adds a raw buffer to a DBPF', function() {
-
-			let dbpf = new DBPF();
-			let png = Buffer.from([
-				0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-			]);
-			dbpf.add([FileType.PNG, 0x01, 0x02], png);
-
-			let buffer = dbpf.toBuffer();
-			let clone = new DBPF(buffer);
-			let entry = clone.find(FileType.PNG, 0x01, 0x02);
-			expect(Buffer.compare(entry.decompress(), png)).to.equal(0);
-
-		});
-
 		it('adds a raw Uint8Array to a DBPF', function() {
 
 			let dbpf = new DBPF();
@@ -233,7 +218,7 @@ describe('A DBPF file', function() {
 			let buffer = dbpf.toBuffer();
 			let clone = new DBPF(buffer);
 			let entry = clone.find(FileType.PNG, 0x01, 0x02);
-			expect(Buffer.compare(entry.decompress(), png)).to.equal(0);
+			expect(compareUint8Arrays(entry.decompress(), png)).to.equal(0);
 
 		});
 

--- a/lib/core/test/dbpf-test.js
+++ b/lib/core/test/dbpf-test.js
@@ -287,7 +287,7 @@ describe('A lot subfile', function() {
 		// the same buffer.
 		let source = entry.decompress();
 		let check = entry.toBuffer();
-		expect(source.toString('hex')).to.equal(check.toString('hex'));
+		expect(compareUint8Arrays(source, check)).to.equal(0);
 
 	});
 
@@ -470,7 +470,7 @@ describe('A prop subfile', function() {
 		// same buffer.
 		let source = entry.decompress();
 		let check = entry.toBuffer();
-		expect(source.toString('hex')).to.equal(check.toString('hex'));
+		expect(compareUint8Arrays(source, check)).to.equal(0);
 
 	});
 
@@ -506,7 +506,7 @@ describe('The flora subfile', function() {
 		// same buffer.
 		let source = entry.decompress();
 		let check = entry.toBuffer();
-		expect(source.toString('hex')).to.equal(check.toString('hex'));
+		expect(compareUint8Arrays(source, check)).to.equal(0);
 
 	});
 
@@ -533,7 +533,7 @@ describe('The network subfile', function() {
 		// same buffer.
 		let source = entry.decompress();
 		let check = entry.toBuffer();
-		expect(source.toString('hex')).to.equal(check.toString('hex'));
+		expect(compareUint8Arrays(source, check)).to.equal(0);
 
 	});
 

--- a/lib/core/test/exemplar-test.js
+++ b/lib/core/test/exemplar-test.js
@@ -1,4 +1,6 @@
 // # exemplar-test.js
+import fs from 'node:fs';
+import { uint8ArrayToHex } from 'uint8array-extras';
 import { expect } from 'chai';
 import { resource } from '#test/files.js';
 import { DBPF, Exemplar, ExemplarProperty, FileType } from 'sc4/core';
@@ -8,6 +10,37 @@ const Props = {
 };
 
 describe('The Exemplar file', function() {
+
+	it('should serialize to a buffer correctly', function() {
+
+		// Read an exemplar from a sample dbpf first.
+		let file = resource('cement.sc4lot');
+		let buff = fs.readFileSync(file);
+		let dbpf = new DBPF(buff);
+
+		let exemplars = dbpf.exemplars;
+		let raw = exemplars.map(entry => entry.decompress());
+
+		for (let i = 0; i < exemplars.length; i++) {
+			let entry = exemplars[i];
+			let exemplar = entry.read();
+			let bin = uint8ArrayToHex(exemplar.toBuffer());
+			let check = uint8ArrayToHex(raw[i]);
+			expect(bin).to.equal(check);
+		}
+
+	});
+
+	it('should read textual exemplars', function() {
+
+		let file = resource('quotes.sc4desc');
+		let buff = fs.readFileSync(file);
+		let dbpf = new DBPF(buff);
+
+		let entry = dbpf.exemplars[0];
+		entry.read();
+
+	});
 
 	it('handles exemplars with multiple DIR entries', function() {
 

--- a/lib/core/test/exemplar-test.js
+++ b/lib/core/test/exemplar-test.js
@@ -1,5 +1,5 @@
 // # exemplar-test.js
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { uint8ArrayToHex } from 'uint8array-extras';
 import { expect } from 'chai';
 import { resource } from '#test/files.js';

--- a/lib/core/test/item-index-test.js
+++ b/lib/core/test/item-index-test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { DBPF, FileType, ItemIndex } from 'sc4/core';
 import { hex } from 'sc4/utils';
 import { resource } from '#test/files.js';
+import { compareUint8Arrays } from 'uint8array-extras';
 
 describe('An item index subfile', function() {
 
@@ -109,7 +110,7 @@ describe('An item index subfile', function() {
 		// should still match.
 		let source = entry.decompress();
 		let check = indexFile.toBuffer();
-		expect(source.toString('hex')).to.equal(check.toString('hex'));
+		expect(compareUint8Arrays(source, check)).to.equal(0);
 
 		// Seems that the item index works with tracts and that it only starts 
 		// at 64. So a lot of the items is apparently never used. Probably 

--- a/lib/core/test/item-index-test.js
+++ b/lib/core/test/item-index-test.js
@@ -1,6 +1,6 @@
 // # item-index-test.js
 import { expect } from 'chai';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { DBPF, FileType, ItemIndex } from 'sc4/core';
 import { hex } from 'sc4/utils';
 import { resource } from '#test/files.js';

--- a/lib/core/test/lot-developer-test.js
+++ b/lib/core/test/lot-developer-test.js
@@ -1,5 +1,6 @@
 // # lot-developer-test.js
 import { expect } from 'chai';
+import { SmartBuffer } from 'smart-arraybuffer';
 import fs from 'node:fs';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
@@ -17,7 +18,7 @@ describe('The LotDeveloper Subfile', function() {
 		expect(dev.buildings).to.have.length(buildings.length);
 
 		let crc = dev.crc;
-		let buff = dev.toBuffer();
+		let buff = SmartBuffer.fromBuffer(dev.toBuffer());
 		expect(buff.readUInt32LE(4)).to.equal(crc);
 
 		// Seems to be something like this:
@@ -47,7 +48,7 @@ describe('The LotDeveloper Subfile', function() {
 		expect(dev.buildings).to.have.length(buildings.length);
 
 		let crc = dev.crc;
-		let buff = dev.toBuffer();
+		let buff = SmartBuffer.fromBuffer(dev.toBuffer());
 		expect(buff.readUInt32LE(4)).to.equal(crc);
 
 	});
@@ -63,7 +64,7 @@ describe('The LotDeveloper Subfile', function() {
 		expect(dev.buildings).to.have.length(buildings.length);
 
 		let crc = dev.crc;
-		let buff = dev.toBuffer();
+		let buff = SmartBuffer.fromBuffer(dev.toBuffer());
 		expect(buff.readUInt32LE(4)).to.equal(crc);
 
 	});

--- a/lib/core/test/lot-developer-test.js
+++ b/lib/core/test/lot-developer-test.js
@@ -1,7 +1,7 @@
 // # lot-developer-test.js
 import { expect } from 'chai';
 import { SmartBuffer } from 'smart-arraybuffer';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
 

--- a/lib/core/test/ltext-test.js
+++ b/lib/core/test/ltext-test.js
@@ -1,6 +1,6 @@
 // # ltext-test.js
 import { expect } from 'chai';
-import { Buffer } from 'node:buffer';
+import { compareUint8Arrays } from 'uint8array-extras';
 import DBPF from '../dbpf.js';
 import { resource } from '#test/files.js';
 
@@ -13,7 +13,7 @@ describe('The LTEXT file type', function() {
 		let ltext = entry.read();
 		expect(ltext.value).to.equal('Signage');
 		let buffer = ltext.toBuffer();
-		expect(Buffer.compare(buffer, entry.buffer)).to.equal(0);
+		expect(compareUint8Arrays(buffer, entry.buffer)).to.equal(0);
 
 	});
 

--- a/lib/core/test/network-test.js
+++ b/lib/core/test/network-test.js
@@ -1,5 +1,5 @@
 // # network-test.js
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { expect } from 'chai';
 import { compareUint8Arrays } from 'uint8array-extras';
 import { resource } from '#test/files.js';

--- a/lib/core/test/network-test.js
+++ b/lib/core/test/network-test.js
@@ -1,7 +1,7 @@
 // # network-test.js
-import { Buffer } from 'node:buffer';
 import fs from 'node:fs';
 import { expect } from 'chai';
+import { compareUint8Arrays } from 'uint8array-extras';
 import { resource } from '#test/files.js';
 import { Savegame, FileType } from 'sc4/core';
 
@@ -15,7 +15,7 @@ describe('The network index', function() {
 		let { networkIndex } = dbpf;
 		let raw = dbpf.find(FileType.NetworkIndex).decompress();
 		let out = networkIndex.toBuffer();
-		expect(Buffer.compare(out, raw)).to.equal(0);
+		expect(compareUint8Arrays(out, raw)).to.equal(0);
 
 	});
 

--- a/lib/core/test/pipes-test.js
+++ b/lib/core/test/pipes-test.js
@@ -1,7 +1,7 @@
 // # pipes-test.js
 import { expect } from 'chai';
 import { compareUint8Arrays } from 'uint8array-extras';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { DBPF } from 'sc4/core';
 import { resource } from '#test/files.js';
 

--- a/lib/core/test/pipes-test.js
+++ b/lib/core/test/pipes-test.js
@@ -1,6 +1,6 @@
 // # pipes-test.js
 import { expect } from 'chai';
-import { Buffer } from 'node:buffer';
+import { compareUint8Arrays } from 'uint8array-extras';
 import fs from 'node:fs';
 import { DBPF } from 'sc4/core';
 import { resource } from '#test/files.js';
@@ -17,7 +17,7 @@ describe('The pipes subfile', function() {
 		let raw = entry.decompress();
 		entry.read();
 		let out = entry.toBuffer();
-		expect(Buffer.compare(out, raw)).to.equal(0);
+		expect(compareUint8Arrays(out, raw)).to.equal(0);
 
 	});
 

--- a/lib/core/test/plumbing-simulator-test.js
+++ b/lib/core/test/plumbing-simulator-test.js
@@ -1,6 +1,7 @@
 // # plumbing-simulator-test.js
 import { expect } from 'chai';
 import fs from 'node:fs';
+import { SmartBuffer } from 'smart-arraybuffer';
 import { Savegame } from 'sc4/core';
 import { resource } from '#test/files.js';
 
@@ -13,7 +14,7 @@ describe('The plumbing simulator file', function() {
 		let dbpf = new Savegame(buffer);
 		let sim = dbpf.plumbingSimulator;
 
-		let out = sim.toBuffer();
+		let out = SmartBuffer.fromBuffer(sim.toBuffer());
 		let crc = out.readUInt32LE(4);
 		expect(crc).to.equal(sim.crc);
 

--- a/lib/core/test/plumbing-simulator-test.js
+++ b/lib/core/test/plumbing-simulator-test.js
@@ -1,6 +1,6 @@
 // # plumbing-simulator-test.js
 import { expect } from 'chai';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { SmartBuffer } from 'smart-arraybuffer';
 import { Savegame } from 'sc4/core';
 import { resource } from '#test/files.js';

--- a/lib/core/test/sim-grid-test.js
+++ b/lib/core/test/sim-grid-test.js
@@ -1,6 +1,6 @@
 // # sim-grid-test.js
 import { expect } from 'chai';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
 import { SmartBuffer } from 'smart-arraybuffer';

--- a/lib/core/test/sim-grid-test.js
+++ b/lib/core/test/sim-grid-test.js
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import fs from 'node:fs';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
+import { SmartBuffer } from 'smart-arraybuffer';
+import { compareUint8Arrays } from 'uint8array-extras';
 
 describe('A SimGrid', function() {
 
@@ -40,13 +42,13 @@ describe('A SimGrid', function() {
 			// Serialize each grid independently.
 			for (let grid of grids) {
 				let crc = grid.crc;
-				let buff = grid.toBuffer();
+				let buff = SmartBuffer.fromBuffer(grid.toBuffer());
 				expect(buff.readUInt32LE(4)).to.equal(crc);
 			}
 
 			// Check the entire grid.
 			let check = entry.decompress();
-			expect(check.toString('hex')).to.equal(entry.buffer.toString('hex'));
+			expect(compareUint8Arrays(check, entry.toBuffer())).to.equal(0);
 
 		}
 

--- a/lib/core/test/terrain-map-test.js
+++ b/lib/core/test/terrain-map-test.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { SmartBuffer } from 'smart-arraybuffer';
 import { compareUint8Arrays } from 'uint8array-extras';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { DBPF, TerrainMap, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
 

--- a/lib/core/test/terrain-map-test.js
+++ b/lib/core/test/terrain-map-test.js
@@ -1,7 +1,7 @@
 // # terrain-map-test.js
 import { expect } from 'chai';
 import { SmartBuffer } from 'smart-arraybuffer';
-import { Buffer } from 'node:buffer';
+import { compareUint8Arrays } from 'uint8array-extras';
 import fs from 'node:fs';
 import { DBPF, TerrainMap, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
@@ -23,7 +23,7 @@ describe('The terrain map', function() {
 
 		let source = entry.decompress();
 		let check = terrain.toBuffer();
-		expect(Buffer.compare(source, check)).to.equal(0);
+		expect(compareUint8Arrays(source, check)).to.equal(0);
 
 	});
 
@@ -37,10 +37,10 @@ describe('The terrain map', function() {
 
 	it('serializes row-first', function() {
 
-		let buff = Buffer.alloc(2+ 4*5**2);
-		buff.writeUint16LE(0, 2);
+		let buff = new ArrayBuffer(2+ 4*5**2);
+		new DataView(buff).setUint16(0, 2, true);
 		let terrain = new TerrainMap();
-		terrain.parse(buff);
+		terrain.parse(new Uint8Array(buff));
 		terrain[0][1] = 10;
 
 		let out = SmartBuffer.fromBuffer(terrain.toBuffer());

--- a/lib/core/test/terrain-map-test.js
+++ b/lib/core/test/terrain-map-test.js
@@ -1,5 +1,6 @@
 // # terrain-map-test.js
 import { expect } from 'chai';
+import { SmartBuffer } from 'smart-arraybuffer';
 import { Buffer } from 'node:buffer';
 import fs from 'node:fs';
 import { DBPF, TerrainMap, FileType } from 'sc4/core';
@@ -42,7 +43,7 @@ describe('The terrain map', function() {
 		terrain.parse(buff);
 		terrain[0][1] = 10;
 
-		let out = terrain.toBuffer();
+		let out = SmartBuffer.fromBuffer(terrain.toBuffer());
 		expect(out.readFloatLE(6)).to.equal(10);
 
 	});

--- a/lib/core/test/texture-file-test.js
+++ b/lib/core/test/texture-file-test.js
@@ -1,6 +1,6 @@
 // # texture-file-test.js
 import { expect } from 'chai';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { hex } from 'sc4/utils';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';

--- a/lib/core/test/texture-file-test.js
+++ b/lib/core/test/texture-file-test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { hex } from 'sc4/utils';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
+import { compareUint8Arrays } from 'uint8array-extras';
 
 describe('A base texture file', function() {
 
@@ -45,7 +46,7 @@ describe('A base texture file', function() {
 		let source = entry.decompress();
 		entry.read();
 		let check = entry.toBuffer();
-		expect(source.toString('hex')).to.equal(check.toString('hex'));
+		expect(compareUint8Arrays(source, check)).to.equal(0);
 
 	});
 

--- a/lib/core/test/tract-developer-test.js
+++ b/lib/core/test/tract-developer-test.js
@@ -1,5 +1,5 @@
 // # tract-developer-test.js
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { expect } from 'chai';
 import { DBPF, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';

--- a/lib/core/test/tract-developer-test.js
+++ b/lib/core/test/tract-developer-test.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import { expect } from 'chai';
 import { DBPF, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
+import { compareUint8Arrays } from 'uint8array-extras';
 
 describe('The tract developer file', function() {
 
@@ -17,7 +18,7 @@ describe('The tract developer file', function() {
 
 		let source = entry.decompress();
 		let check = tract.toBuffer();
-		expect(check.toString('hex')).to.equal(source.toString('hex'));
+		expect(compareUint8Arrays(check, source)).to.equal(0);
 
 	});
 

--- a/lib/core/test/write-buffer-test.js
+++ b/lib/core/test/write-buffer-test.js
@@ -1,6 +1,8 @@
 // # write-stream-test.js
 import { expect } from 'chai';
+import { SmartBuffer } from 'smart-arraybuffer';
 import WriteBuffer from '../write-buffer.js';
+import { uint8ArrayToString } from 'uint8array-extras';
 
 describe('A WriteBuffer', function() {
 
@@ -9,9 +11,9 @@ describe('A WriteBuffer', function() {
 		let buffer = new WriteBuffer();
 		let str = 'Hello world!';
 		buffer.string(str);
-		let out = buffer.toBuffer();
+		let out = buffer.toUint8Array();
 		expect(out.length).to.equal(4+str.length);
-		expect(out.slice(4).toString('utf8')).to.equal(str);
+		expect(uint8ArrayToString(out.subarray(4))).to.equal(str);
 
 	});
 
@@ -20,7 +22,7 @@ describe('A WriteBuffer', function() {
 		let buffer = new WriteBuffer();
 		buffer.int16(16);
 		buffer.int32(32);
-		let out = buffer.toBuffer();
+		let out = SmartBuffer.fromBuffer(buffer.toUint8Array());
 		expect(out.length).to.equal(2+4);
 		expect(out.readInt16LE(0)).to.equal(16);
 		expect(out.readInt32LE(2)).to.equal(32);
@@ -31,7 +33,7 @@ describe('A WriteBuffer', function() {
 
 		let buffer = new WriteBuffer();
 		buffer.bigint64(100n);
-		let out = buffer.toBuffer();
+		let out = SmartBuffer.fromBuffer(buffer.toArrayBuffer());
 		expect(out).to.have.length(8);
 		let int = out.readBigInt64LE(0);
 		expect(int).to.equal(100n);
@@ -42,8 +44,8 @@ describe('A WriteBuffer', function() {
 
 		let buffer = new WriteBuffer();
 		buffer.bigint64(10);
-		let out = buffer.toBuffer();
-		expect(out.readBigInt64LE(0)).to.equal(10n);
+		let out = new DataView(buffer.toArrayBuffer());
+		expect(out.getBigInt64(0, true)).to.equal(10n);
 
 	});
 
@@ -66,10 +68,10 @@ describe('A WriteBuffer', function() {
 			obj,
 		];
 		buffer.array(arr);
-		let out = buffer.toBuffer();
+		let out = SmartBuffer.fromBuffer(buffer.toArrayBuffer());
 		expect(out).to.have.length(4+3+3);
 		expect(out.readUInt32LE(0)).to.equal(arr.length);
-		expect(out.toString('utf8', 4)).to.equal('foobar');
+		expect(out.toString('utf8').slice(4)).to.equal('foobar');
 
 	});
 

--- a/lib/core/test/write-buffer-test.js
+++ b/lib/core/test/write-buffer-test.js
@@ -1,6 +1,5 @@
 // # write-stream-test.js
 import { expect } from 'chai';
-import { Buffer } from 'buffer';
 import WriteBuffer from '../write-buffer.js';
 
 describe('A WriteBuffer', function() {
@@ -60,10 +59,10 @@ describe('A WriteBuffer', function() {
 
 	it('automatically writes arrays', function() {
 
-		let obj = { toBuffer: () => Buffer.from('bar') };
+		let obj = { toBuffer: () => new Uint8Array([0x62, 0x61, 0x72]) };
 		let buffer = new WriteBuffer();
 		let arr = [
-			Buffer.from('foo'),
+			new Uint8Array([0x66, 0x6f, 0x6f]),
 			obj,
 		];
 		buffer.array(arr);

--- a/lib/core/test/zone-developer-test.js
+++ b/lib/core/test/zone-developer-test.js
@@ -1,6 +1,6 @@
 // # zone-developer-test.js
 import { expect } from 'chai';
-import fs from 'node:fs';
+import fs from '#test/fs.js';
 import { SmartBuffer } from 'smart-arraybuffer';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';

--- a/lib/core/test/zone-developer-test.js
+++ b/lib/core/test/zone-developer-test.js
@@ -1,6 +1,7 @@
 // # zone-developer-test.js
 import { expect } from 'chai';
 import fs from 'node:fs';
+import { SmartBuffer } from 'smart-arraybuffer';
 import { Savegame, FileType } from 'sc4/core';
 import { resource } from '#test/files.js';
 
@@ -27,7 +28,7 @@ describe('The ZoneDeveloper Subfile', function() {
 
 		// Now serialize again & check that the CRC still matches.
 		let crc = dev.crc;
-		let buff = dev.toBuffer();
+		let buff = SmartBuffer.fromBuffer(dev.toBuffer());
 		expect(buff.readUInt32LE(4)).to.equal(crc);
 
 	});
@@ -57,7 +58,7 @@ describe('The ZoneDeveloper Subfile', function() {
 
 		// Now serialize again & check that the CRC still matches.
 		let crc = dev.crc;
-		let buff = dev.toBuffer();
+		let buff = SmartBuffer.fromBuffer(dev.toBuffer());
 		expect(buff.readUInt32LE(4)).to.equal(crc);
 
 	});
@@ -87,7 +88,7 @@ describe('The ZoneDeveloper Subfile', function() {
 
 		// Now serialize again & check that the CRC still matches.
 		let crc = dev.crc;
-		let buff = dev.toBuffer();
+		let buff = SmartBuffer.fromBuffer(dev.toBuffer());
 		expect(buff.readUInt32LE(4)).to.equal(crc);
 
 	});

--- a/lib/core/unknown.js
+++ b/lib/core/unknown.js
@@ -1,6 +1,4 @@
 // # unknown.js
-import { Buffer } from 'buffer';
-
 // # Unknown
 // Helper class that we use for easily managing unknown values in data 
 // structures used by the game.
@@ -36,7 +34,7 @@ export default class Unknown extends Array {
 	dword(...args) { this.add(...args); }
 	float(...args) { this.add(...args); }
 	double(...args) { this.add(...args); }
-	bytes(bytes, ...rest) { this.add(Buffer.from(bytes), ...rest); }
+	bytes(bytes, ...rest) { this.add(new Uint8Array(bytes), ...rest); }
 	generator() {
 		let it = this[Symbol.iterator]();
 		return () => it.next().value;

--- a/lib/core/write-buffer.js
+++ b/lib/core/write-buffer.js
@@ -1,6 +1,5 @@
 // # smart-buffer.js
-import { SmartBuffer } from 'smart-buffer';
-import { Buffer } from 'buffer';
+import { SmartBuffer } from 'smart-arraybuffer';
 import xcrc from './crc.js';
 
 // # WriteBuffer()
@@ -10,6 +9,7 @@ import xcrc from './crc.js';
 // easier to work with. Under the hood we'll also provide support for 
 // "formatting" the buffer, i.e. adding the size and the checksum in front of 
 // it automatically, which is what we often need.
+const encoder = new TextEncoder();
 export default class WriteBuffer extends SmartBuffer {
 
 	// ## write(buffer, ...rest)
@@ -20,7 +20,7 @@ export default class WriteBuffer extends SmartBuffer {
 		// either:
 		//  - the object supports writing to the buffer.
 		//  - the object has a `toBuffer()` method.
-		if (!Buffer.isBuffer(buffer)) {
+		if (!(buffer instanceof Uint8Array)) {
 			if (buffer.write) {
 				buffer.write(this);
 				return;
@@ -36,7 +36,7 @@ export default class WriteBuffer extends SmartBuffer {
 	// then the string itself.
 	string(str, opts = {}) {
 		let { length = true } = opts;
-		let buffer = Buffer.from(str, 'utf8');
+		let buffer = encoder.encode(str);
 		if (length) {
 			this.writeUInt32LE(buffer.byteLength);
 		}
@@ -112,14 +112,13 @@ export default class WriteBuffer extends SmartBuffer {
 	seal() {
 
 		// First of all we'll calculate the CRC checksum for the buffer.
-		let buffer = this.toBuffer();
+		let buffer = this.toUint8Array();
 		let sum = xcrc(buffer);
 
 		// Next we'll prefix it with the size and calculated checksum.
-		let prefix = Buffer.allocUnsafe(8);
-		prefix.writeUInt32LE(buffer.length + prefix.length, 0);
-		prefix.writeUInt32LE(sum, 4);
-		return Buffer.concat([prefix, buffer]);
+		this.insertUInt32LE(buffer.length + 8, 0);
+		this.insertUInt32LE(sum, 4);
+		return this.toBuffer();
 
 	}
 

--- a/lib/core/write-buffer.js
+++ b/lib/core/write-buffer.js
@@ -118,8 +118,14 @@ export default class WriteBuffer extends SmartBuffer {
 		// Next we'll prefix it with the size and calculated checksum.
 		this.insertUInt32LE(buffer.length + 8, 0);
 		this.insertUInt32LE(sum, 4);
-		return this.toBuffer();
+		return this.toUint8Array();
 
+	}
+
+	// ## toBuffer()
+	toBuffer() {
+		console.warn('`.toBuffer()` only works in Node.js environments and should be avoided. Use `.toUint8Array()` instead!');
+		return super.toBuffer();
 	}
 
 }

--- a/lib/core/zone-developer-file.js
+++ b/lib/core/zone-developer-file.js
@@ -1,5 +1,4 @@
 // # zone-developer-file.js
-import Stream from './stream.js';
 import WriteBuffer from './write-buffer.js';
 import { FileType } from './enums.js';
 
@@ -18,11 +17,9 @@ export default class ZoneDeveloperFile {
 		this.cells = [];
 	}
 
-	// ## parse(buff, opts)
-	parse(buff, opts) {
-
-		let rs = new Stream(buff);
-		let size = rs.dword();
+	// ## parse(rs)
+	parse(rs) {
+		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
 		this.major = rs.word();
@@ -38,13 +35,7 @@ export default class ZoneDeveloperFile {
 				column[z] = rs.pointer();
 			}
 		}
-
-		if (rs.i !== size) {
-			console.warn([
-				'Error when reading the ZoneDeveloperFile!',
-				`Expected ${size} bytes, but read ${rs.i}!`,
-			].join(' '));
-		}
+		rs.assert();
 
 		// Done.
 		return this;

--- a/lib/core/zone-manager.js
+++ b/lib/core/zone-manager.js
@@ -1,5 +1,5 @@
 // # zone-manager.js
-import { Buffer } from 'buffer';
+import { hexToUint8Array } from 'uint8array-extras';
 import Stream from './stream.js';
 import WriteBuffer from './write-buffer.js';
 import Pointer from './pointer.js';
@@ -34,7 +34,7 @@ export default class ZoneManager {
 		this.size = 0x00000000;
 
 		// From now on follows a part that always seems to be fixed.
-		this.u2 = Buffer.from(fixed, 'hex');
+		this.u2 = hexToUint8Array(fixed);
 
 		// Pointers to other subfiles.
 		this.city = new Pointer(cSC4City);

--- a/lib/threading/test/worker-pool-test.js
+++ b/lib/threading/test/worker-pool-test.js
@@ -7,11 +7,11 @@ import WorkerPool from '../worker-pool.js';
 // # logUsage()
 // Helper function for logging the current usage of a worker pool.
 function logUsage(pool) {
-	let usage = pool.getUsage().map(n => {
+	return pool.getUsage().map(n => {
 		let color = ['gray', 'cyan', 'green', 'yellow', 'red', 'magentaBright'][n] || 'magenta';
 		return chalk[color](n);
 	}).join(' ');
-	console.log(usage);
+	// console.log(usage);
 }
 
 describe('A worker pool', function(argument) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "ora": "^8.1.1",
         "p-queue": "^8.0.1",
         "package-up": "^5.0.0",
-        "qfs-compression": "^0.2.1",
+        "qfs-compression": "^0.2.3",
         "semver": "^7.3.5",
         "smart-arraybuffer": "^1.0.0-alpha.2",
         "tar": "^6.1.8",
@@ -3689,9 +3689,10 @@
       }
     },
     "node_modules/qfs-compression": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/qfs-compression/-/qfs-compression-0.2.1.tgz",
-      "integrity": "sha512-LEgPkitW6yGI4i4ReXW92AvRO4u7rJpmZsyeopSGM+qSGDgXikPIP2YFkRHRIlFtySfNN5bS9zVYtKNl3QtKDA=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/qfs-compression/-/qfs-compression-0.2.3.tgz",
+      "integrity": "sha512-9jS4HdvjUuLGt6nW5ISojhwI4YPgJlojrj7OPRPqMUzSlMu7gUF4m1iPPjuNJQZwTO7i0buAK6kG+0oSFNwXeQ==",
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -6766,9 +6767,9 @@
       "dev": true
     },
     "qfs-compression": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/qfs-compression/-/qfs-compression-0.2.1.tgz",
-      "integrity": "sha512-LEgPkitW6yGI4i4ReXW92AvRO4u7rJpmZsyeopSGM+qSGDgXikPIP2YFkRHRIlFtySfNN5bS9zVYtKNl3QtKDA=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/qfs-compression/-/qfs-compression-0.2.3.tgz",
+      "integrity": "sha512-9jS4HdvjUuLGt6nW5ISojhwI4YPgJlojrj7OPRPqMUzSlMu7gUF4m1iPPjuNJQZwTO7i0buAK6kG+0oSFNwXeQ=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "package-up": "^5.0.0",
         "qfs-compression": "^0.2.1",
         "semver": "^7.3.5",
-        "smart-buffer": "^4.1.0",
+        "smart-arraybuffer": "^1.0.0-alpha.1",
         "tar": "^6.1.8",
         "uint8array-extras": "^1.4.0",
         "yaml": "^2.6.0"
@@ -3867,13 +3867,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+    "node_modules/smart-arraybuffer": {
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/smart-arraybuffer/-/smart-arraybuffer-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-9z85JWRoWa+Y0Yb1cprRV3DTyf5hsbE56V7Q+l0o6yUTxLzUuJBqS2hpMfI0gAIt/+Lv7IBlScmON4xXQS/wfQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/stdin-discarder": {
@@ -6873,10 +6873,10 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
-    "smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+    "smart-arraybuffer": {
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/smart-arraybuffer/-/smart-arraybuffer-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-9z85JWRoWa+Y0Yb1cprRV3DTyf5hsbE56V7Q+l0o6yUTxLzUuJBqS2hpMfI0gAIt/+Lv7IBlScmON4xXQS/wfQ=="
     },
     "stdin-discarder": {
       "version": "0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "package-up": "^5.0.0",
         "qfs-compression": "^0.2.1",
         "semver": "^7.3.5",
-        "smart-arraybuffer": "^1.0.0-alpha.1",
+        "smart-arraybuffer": "^1.0.0-alpha.2",
         "tar": "^6.1.8",
         "uint8array-extras": "^1.4.0",
         "yaml": "^2.6.0"
@@ -3868,9 +3868,9 @@
       }
     },
     "node_modules/smart-arraybuffer": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/smart-arraybuffer/-/smart-arraybuffer-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-9z85JWRoWa+Y0Yb1cprRV3DTyf5hsbE56V7Q+l0o6yUTxLzUuJBqS2hpMfI0gAIt/+Lv7IBlScmON4xXQS/wfQ==",
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/smart-arraybuffer/-/smart-arraybuffer-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-RSfUfkIOyqICtQ9rE65rHTyi8WuiXHK0o9F3nAsio2wnmO9eLyTZL9RSi2o25qTZ6B/FDV53qZZoY56gjThh9g==",
       "license": "MIT",
       "engines": {
         "node": ">= 18.0.0"
@@ -6874,9 +6874,9 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
     "smart-arraybuffer": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/smart-arraybuffer/-/smart-arraybuffer-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-9z85JWRoWa+Y0Yb1cprRV3DTyf5hsbE56V7Q+l0o6yUTxLzUuJBqS2hpMfI0gAIt/+Lv7IBlScmON4xXQS/wfQ=="
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/smart-arraybuffer/-/smart-arraybuffer-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-RSfUfkIOyqICtQ9rE65rHTyi8WuiXHK0o9F3nAsio2wnmO9eLyTZL9RSi2o25qTZ6B/FDV53qZZoY56gjThh9g=="
     },
     "stdin-discarder": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "package-up": "^5.0.0",
     "qfs-compression": "^0.2.1",
     "semver": "^7.3.5",
-    "smart-buffer": "^4.1.0",
+    "smart-arraybuffer": "^1.0.0-alpha.1",
     "tar": "^6.1.8",
     "uint8array-extras": "^1.4.0",
     "yaml": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "ora": "^8.1.1",
     "p-queue": "^8.0.1",
     "package-up": "^5.0.0",
-    "qfs-compression": "^0.2.1",
+    "qfs-compression": "^0.2.3",
     "semver": "^7.3.5",
     "smart-arraybuffer": "^1.0.0-alpha.2",
     "tar": "^6.1.8",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "package-up": "^5.0.0",
     "qfs-compression": "^0.2.1",
     "semver": "^7.3.5",
-    "smart-arraybuffer": "^1.0.0-alpha.1",
+    "smart-arraybuffer": "^1.0.0-alpha.2",
     "tar": "^6.1.8",
     "uint8array-extras": "^1.4.0",
     "yaml": "^2.6.0"

--- a/test/fs.js
+++ b/test/fs.js
@@ -1,0 +1,24 @@
+// # fs.js
+// Our goal is to make the entire module independent of the Node.js buffer - at 
+// least the core functionality - so in order to make sure that we don't 
+// accidentally rely on it, we wrap the filesystem access functions to return 
+// actual Uint8Arrays instead of Buffers.
+import fs from 'node:fs';
+
+export function readFileSync(file) {
+	return wrap(fs.readFileSync(file));
+}
+
+export const { existsSync } = fs;
+
+export const promises = {
+	async readFile(file) {
+		return wrap(await fs.promises.readFile);
+	},
+};
+
+function wrap(buffer) {
+	return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+}
+
+export default { readFileSync, existsSync };


### PR DESCRIPTION
This PR removes all functionality that requirs on Node.js' built-in `Buffer`. Every function that used to return a `Buffer` now returns a `Uint8Array` instead. This ensures the module works seamlessly in the browser without the need for a [buffer polyfill](https://npmjs.com/package/buffer) (fixes #12).

Note that this is a **breaking change**. If you are using this module and relying on the fact that `DBPF.prototype.toBuffer()` returns a Node.js Buffer, then you have the following options:

 - Wrap the returned Uint8Array in a Buffer: `let buffer = Buffer.from(dbpf.toBuffer().buffer);`
 - No longer rely on the Buffer global yourself (recommended), and use something like [smart-arraybuffer](https://npmjs.com/package/smart-arraybuffer).

Inspired by [this article](https://sindresorhus.com/blog/goodbye-nodejs-buffer) by Sindre Sorhus.