### PR TITLE
fix: fix out of memory when tracking dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "chai": "^5.1.2",
         "chai-spies": "^1.0.0",
         "copyfiles": "^2.4.1",
+        "cross-env": "^7.0.3",
         "esbuild": "^0.24.0",
         "eslint": "^9.14.0",
         "hilbert-curve": "^2.0.5",
@@ -1951,6 +1952,25 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6787,6 +6807,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "scripts": {
     "lint": "eslint src",
-    "test": "npm run typecheck && mocha src/**/*-test.js src/**/*-test.ts",
+    "test": "npm run typecheck && npm run test:mocha",
+    "test:mocha": "cross-env NODE_ENV=test mocha src/**/*-test.js src/**/*-test.ts --reporter progress",
     "prebuild": "rimraf lib",
     "typecheck": "tsc --noEmit",
     "build": "tsc -p tsconfig.build.json && copyfiles -u 1 src/cli/assets/* lib",
@@ -70,6 +71,7 @@
     "chai": "^5.1.2",
     "chai-spies": "^1.0.0",
     "copyfiles": "^2.4.1",
+    "cross-env": "^7.0.3",
     "esbuild": "^0.24.0",
     "eslint": "^9.14.0",
     "hilbert-curve": "^2.0.5",

--- a/src/plugins/dependency-tracker.ts
+++ b/src/plugins/dependency-tracker.ts
@@ -169,7 +169,7 @@ export default class DependencyTracker {
 	// ## track(patterns)
 	// Performs the actual dependency tracking. Returns an array of filenames 
 	// that are needed by the source files.
-	async track(patterns = []) {
+	async track(patterns: string | string[] = []) {
 
 		// If the index hasn't been built yet, we'll do this first. The index is 
 		// stored per instance so that we can track dependencies multiple times 
@@ -392,8 +392,9 @@ class DependencyTrackingContext {
 			case LotObjectType.Building:
 			case LotObjectType.Prop:
 			case LotObjectType.Flora:
-				entries = this.index.family(iid);
-				if (entries) {
+				let familyEntries = this.index.family(iid);
+				if (familyEntries) {
+					entries = familyEntries;
 					family = iid;
 				}
 		}

--- a/src/plugins/dependency-tracker.ts
+++ b/src/plugins/dependency-tracker.ts
@@ -3,7 +3,15 @@ import chalk from 'chalk';
 import { Glob } from 'glob';
 import path from 'node:path';
 import fs from 'node:fs';
-import { DBPF, FileType, LotObjectType, ExemplarProperty, Exemplar, LotObject, Cohort } from 'sc4/core';
+import {
+	Cohort,
+	DBPF,
+	FileType,
+	Exemplar,
+	ExemplarProperty,
+	LotObjectType,
+	LotObject,
+} from 'sc4/core';
 import { hex } from 'sc4/utils';
 import PluginIndex from './plugin-index.js';
 import FileScanner from './file-scanner.js';
@@ -14,7 +22,6 @@ import type { Logger, TGIQuery } from 'sc4/types';
 import PQueue from 'p-queue';
 
 // Constants
-const LotConfigurations = 0x00000010;
 const RKT = [
 	0x27812820,
 	0x27812821,
@@ -295,7 +302,7 @@ class DependencyTrackingContext {
 		this.touch(entry);
 		let [type] = [exemplar.get(0x10)].flat();
 		let tasks = [];
-		if (type === LotConfigurations) {
+		if (type === ExemplarProperty.ExemplarType.LotConfigurations) {
 			tasks.push(this.readLotExemplar(exemplar, entry));
 		} else {
 			tasks.push(this.readRktExemplar(exemplar, entry));

--- a/src/plugins/dependency-types.ts
+++ b/src/plugins/dependency-types.ts
@@ -258,7 +258,7 @@ export class Model extends Dependency {
 	kind = 'model';
 
 	// ## toLines()
-	toLines({ width = DEFAULT_WIDTH, level = 0 } = {}) {
+	toLines({ width = DEFAULT_WIDTH, level = 0 }: ToLinesOptions = {}) {
 		let { entry } = this;
 		let lines = [];
 		lines.push($(
@@ -342,7 +342,7 @@ export class Exemplar extends Dependency {
 	}
 
 	// ## toLines(opts)
-	toLines({ width = DEFAULT_WIDTH, level = 0, root = true } = {}) {
+	toLines({ width = DEFAULT_WIDTH, level = 0, root = true }: ToLinesOptions = {}) {
 		let lines = [];
 		let { name, entry } = this;
 		if (root) {
@@ -417,14 +417,20 @@ export class Missing extends Dependency {
 	constructor(entry: EntryLike) {
 		super({ entry });
 	}
-	toLines({ level = 0 } = {}) {
+	toLines({ width = DEFAULT_WIDTH, level = 0 }: ToLinesOptions = {}) {
 		const { type, group, instance } = this.entry;
-		let prefix = `${' '.repeat(2*level)} ${chalk.red('MISSING')}`;
+		let prefix = `${' '.repeat(2*level)}`;
 		if (!type) {
-			return [`${prefix}${chalk.yellow(prefix)}`];
+			return [$(
+				width,
+				`${prefix}${chalk.yellow(hex(instance))}`,
+			)];
 		} else if (instance && group) {
 			let tgi = [type, group, instance].map(x => chalk.yellow(hex(x)));
-			return [`${prefix} ${tgi}`];
+			return [$(
+				width,
+				`${prefix}${tgi}`,
+			)];
 		} else {
 			return [];
 		}
@@ -452,7 +458,7 @@ function entryToString({ type, group, instance }: EntryLike) {
 	}
 }
 
-function $(width: number, line: string, file: string | null | undefined) {
+function $(width: number, line: string, file?: string | null | undefined) {
 	// eslint-disable-next-line no-control-regex
 	let filtered = line.replaceAll(/\x1B\[\d+m/g, '');
 	let basename = file ? path.basename(file) : 'Not found';

--- a/src/plugins/plugin-index.ts
+++ b/src/plugins/plugin-index.ts
@@ -333,7 +333,7 @@ export default class PluginIndex {
 	// ## family(id)
 	// Checks if the a prop or building family exists with the given IID and 
 	// if so returns the family array.
-	family(id: uint32) {
+	family(id: uint32): ExemplarEntry[] | null {
 		let arr = this.families[h(id)];
 		return arr || null;
 	}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import type { ConditionalKeys } from 'type-fest';
+import type { ConditionalKeys, RequireAtLeastOne } from 'type-fest';
 
 export type byte = number;
 export type uint8 = number;
@@ -23,7 +23,7 @@ export type TGIQuery<
 	T extends uint32 = uint32,
 	G extends uint32 = uint32,
 	I extends uint32 = uint32
-> = Partial<TGILiteral<T, G, I>>;
+> = RequireAtLeastOne<TGILiteral<T, G, I>>;
 export type TGIArray<
 	T extends uint32 = uint32,
 	G extends uint32 = uint32,

--- a/src/utils/test/tgi-index-test.ts
+++ b/src/utils/test/tgi-index-test.ts
@@ -143,6 +143,18 @@ const fn = (create: (arr: any[]) => Index) => () => {
 
 		});
 
+		it('returns nothing if the query is empty', function() {
+
+			let values = [
+				new TGI(4, 5, 6),
+				new TGI(1, 2, 3),
+			];
+			let index = create(values);
+			let result = index.findAll({} as TGILiteral);
+			expect(result).to.have.length(0);
+
+		});
+
 	});
 
 	describe('#add()', function() {

--- a/src/utils/tgi-index.ts
+++ b/src/utils/tgi-index.ts
@@ -276,7 +276,9 @@ function normalize(
 		group === undefined &&
 		instance === undefined
 	) {
-		console.warn('You provided an empty TGI query. Please verify if this is intentional! To avoid performance problems, this returns an empty result instead of all entries.');
+		if (process.env.NODE_ENV !== 'test') {
+			console.warn('You provided an empty TGI query. Please verify if this is intentional! To avoid performance problems, this returns an empty result instead of all entries.');
+		}
 		return null;
 	}
 	let result: any = {};

--- a/src/utils/tgi-index.ts
+++ b/src/utils/tgi-index.ts
@@ -77,6 +77,7 @@ export default class TGIIndex<T extends TGILiteral = TGILiteral> extends Array<T
 		// If we have no index, then we have no choice but to loop everything 
 		// manually.
 		let q = normalize(query, group, instance);
+		if (!q) return [];
 		if (!this.index) {
 			return super.filter(createFilter(q));
 		}
@@ -130,8 +131,9 @@ export default class TGIIndex<T extends TGILiteral = TGILiteral> extends Array<T
 		if (typeof query === 'function') {
 			removed = filterInPlace<T>(this, query);
 		} else {
-			let fn = createFilter(normalize(query, g, i));
-			removed = filterInPlace<T>(this, fn);
+			let normalizedQuery = normalize(query, g, i);
+			if (!normalizedQuery) return 0;
+			removed = filterInPlace<T>(this, createFilter(normalizedQuery));
 		}
 		if (this.index) {
 			this.dirty = true;
@@ -256,8 +258,10 @@ function normalize(
 	query: TGIQuery | number[] | number,
 	g?: number,
 	i?: number,
-): TGIQuery {
-	let type, group, instance;
+): TGIQuery | null{
+	let type: number | undefined;
+	let group: number | undefined;
+	let instance: number | undefined;
 	if (typeof query === 'number') {
 		type = query;
 		group = g;
@@ -267,7 +271,19 @@ function normalize(
 	} else {
 		({ type, group, instance } = query);
 	}
-	return { type, group, instance };
+	if (
+		type === undefined &&
+		group === undefined &&
+		instance === undefined
+	) {
+		console.warn('You provided an empty TGI query. Please verify if this is intentional! To avoid performance problems, this returns an empty result instead of all entries.');
+		return null;
+	}
+	let result: any = {};
+	if (type !== undefined) result.type = type;
+	if (group !== undefined) result.group = group;
+	if (instance !== undefined) result.instance = instance;
+	return result as TGIQuery;
 }
 
 // # createFilter(query)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 			"sc4/api": ["src/api/api.js"],
 			"sc4/api/*": ["src/api/*"],
 			"sc4/types": ["src/types/types.ts"],
+			"#cli/*": ["src/cli/*"],
 		},
 		"lib": ["es2022"],
 		"target": "es2022",


### PR DESCRIPTION
This PR fixes an issue that we discovered in the wake of https://github.com/memo33/sc4pac/pull/54. If the dependencies of a transit enabled lot are being tracked, where the transit enabled lot has no custom paths set - meaning [rep 16 of the LotConfigPropertyLotObject](https://wiki.sc4devotion.com/index.php?title=LotConfigPropertyLotObject) is not present - then the dependencies of *every resource in your entire plugin folder* were tracked, which quickly crashes the JS process due to memory constraints.