### PR TITLE
refactor: implement additional data structures

### DIFF
--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -64,20 +64,6 @@ type ZoneOptions = {
 	zoneType?: number;
 };
 
-type CreateLotOptions = {
-	exemplar: Entry<Exemplar>;
-	building: Entry<Exemplar>;
-	x: number;
-	z: number;
-	orientation: Orientation;
-};
-
-type CreateBuildingOptions = {
-	lot: Lot,
-	lotObject: LotObject;
-	exemplar: Entry<Exemplar>;
-};
-
 // # CityManager
 // A class for performing operations on a certain city, such as plopping 
 // arbitrary lots etc. Have a look at https://sc4devotion.com/forums/
@@ -513,7 +499,11 @@ export default class CityManager {
 
 	// ## createBuilding(opts)
 	// Creates a new building record and inserts it into the savegame.
-	createBuilding(opts: CreateBuildingOptions) {
+	createBuilding(opts: {
+		lot: Lot,
+		lotObject: LotObject;
+		exemplar: Entry<Exemplar>;
+	}) {
 		let { lot, lotObject, exemplar } = opts;
 		let file = exemplar.read();
 		let [, height] = this.getPropertyValue(file, Property.OccupantSize)!;

--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -528,7 +528,7 @@ export default class CityManager {
 			IID1: exemplar.instance,
 
 		});
-		setTract(building);
+		building.tract.update(building);
 
 		// Put the building in the index at the correct spot.
 		let { dbpf } = this;
@@ -593,7 +593,7 @@ export default class CityManager {
 			state: 0,
 
 		});
-		setTract(prop);
+		prop.tract.update(prop);
 
 		// Push in the file with all props.
 		let { dbpf } = this;
@@ -636,7 +636,7 @@ export default class CityManager {
 			mem: this.mem(),
 			bbox: new Box3([minX, minY, minZ], [maxX, maxY, maxZ]),
 		});
-		setTract(texture);
+		texture.tract.update(texture);
 
 		// Add all required textures.
 		for (let def of textures) {
@@ -741,19 +741,6 @@ export default class CityManager {
 
 	}
 
-}
-
-// ## setTract(obj)
-// Helper function for setting the correct "Tract" values in the given object 
-// based on its bounding box.
-function setTract(obj: SavegameObject & { bbox: Box3 }) {
-	const xSize = 16 * 2**obj.xTractSize;
-	const zSize = 16 * 2**obj.zTractSize;
-	const { bbox } = obj;
-	obj.xMinTract = Math.max(64, 64 + Math.floor(bbox.minX / xSize));
-	obj.xMaxTract = 64 + Math.floor(bbox.maxX / xSize);
-	obj.zMinTract = Math.max(64, 64 + Math.floor(bbox.minZ / zSize));
-	obj.zMaxTract = 64 + Math.floor(bbox.maxZ / zSize);
 }
 
 // ## orient([x, y], lot, opts)

--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -10,6 +10,7 @@ import {
 	FileType,
 	SimGrid,
 	ExemplarProperty as Property,
+	Box3,
 	type Exemplar,
     type ExemplarPropertyKey as Key,
     type Entry,
@@ -20,7 +21,6 @@ import {
 } from 'sc4/core';
 import type { PluginIndex } from 'sc4/plugins';
 import type { TGIArray, TGIQuery } from 'sc4/types';
-import Box3 from 'src/core/box3.js';
 
 const INSET = 0.1;
 

--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -1,4 +1,4 @@
-// # city-manager.js
+// # city-manager.ts
 import { path, fs, hex } from 'sc4/utils';
 import {
 	Savegame,
@@ -9,38 +9,90 @@ import {
 	Pointer,
 	FileType,
 	SimGrid,
+	ExemplarProperty as Property,
+	type Exemplar,
+    type ExemplarPropertyKey as Key,
+    type Entry,
+    type LotObject,
+    type SavegameObject,
+    type ArrayFileTypeId,
+    type SavegameFileTypeId,
 } from 'sc4/core';
+import type { PluginIndex } from 'sc4/plugins';
+import type { TGIArray, TGIQuery } from 'sc4/types';
 
-// Hex constants to make the code more readable.
-const ExemplarType = 0x10;
-const Buildings = 0x02;
-const OccupantSize = 0x27812810;
-const LotConfigurations = 0x10;
-const LotResourceKey = 0xea260589;
-const LotConfigPropertySize = 0x88edc790;
-const LotConfigPropertyZoneTypes = 0x88edc793;
-const Wealth = 0x27812832;
 const INSET = 0.1;
+
+type CityManagerOptions = {
+	dbpf?: Savegame;
+	index?: PluginIndex;
+};
+
+type Orientation = 0 | 1 | 2 | 3;
+type PlopOptions = {
+	tgi?: TGIQuery | TGIArray;
+	building?: Entry<Exemplar>;
+	x: number;
+	z: number;
+	orientation?: Orientation;
+};
+
+type GrowOptions = {
+	tgi?: TGIQuery | TGIArray;
+	lot?: Entry<Exemplar>;
+	building?: Entry<Exemplar>;
+	x: number;
+	z: number;
+	orientation?: Orientation;
+};
+
+type BuildOptions = {
+	lot: Entry<Exemplar>;
+	building: Entry<Exemplar>;
+	x: number;
+	z: number;
+	orientation?: Orientation;
+};
+
+type ZoneOptions = {
+	x: number;
+	z: number;
+	width?: number;
+	depth?: number;
+	orientation?: Orientation;
+	zoneType?: number;
+};
+
+type CreateLotOptions = {
+	exemplar: Entry<Exemplar>;
+	building: Entry<Exemplar>;
+	x: number;
+	z: number;
+	orientation: Orientation;
+};
+
+type CreateBuildingOptions = {
+	lot: Lot,
+	lotObject: LotObject;
+	exemplar: Entry<Exemplar>;
+};
 
 // # CityManager
 // A class for performing operations on a certain city, such as plopping 
 // arbitrary lots etc. Have a look at https://sc4devotion.com/forums/
 // index.php?topic=5656.0, contains a lot of relevant info.
 export default class CityManager {
+	dbpf: Savegame;
+	index: PluginIndex;
+	memRefs: Set<number> = new Set();
+	#mem = 1;
 
 	// ## constructor(opts)
 	// Sets up the city manager.
-	constructor(opts = {}) {
-		
-		// Pre-initialize the "private" fields that cannot be modified by the 
-		// options.
-		this.memRefs = null;
-		this.$mem = 1;
-
-		// Setup the "public" fields.
-		this.dbpf = opts.dbpf || null;
-		this.index = opts.index || null;
-
+	constructor(opts: CityManagerOptions = {}) {
+		let { dbpf, index } = opts;
+		if (dbpf) this.dbpf = dbpf;
+		if (index) this.index = index;
 	}
 
 	// ## get city()
@@ -53,13 +105,13 @@ export default class CityManager {
 	// Stores the file index to be used for looking up TGI's etc. That's 
 	// required if you want to plop lot's etc. because in that case we need to 
 	// know where to look for the resources!
-	setFileIndex(index) {
+	setFileIndex(index: PluginIndex) {
 		this.index = index;
 	}
 
 	// ## load(file)
 	// Loads the given savegame into the city manager.
-	load(file) {
+	load(file: string) {
 
 		// No extension given? Add .sc4
 		let full = path.resolve(process.env.SC4_REGIONS ?? process.cwd(), file);
@@ -95,7 +147,7 @@ export default class CityManager {
 
 	// ## save(opts)
 	// Saves the city to the given file.
-	save(opts) {
+	save(opts: Parameters<Savegame['save']>[0]) {
 		return this.dbpf.save(opts);
 	}
 
@@ -106,9 +158,9 @@ export default class CityManager {
 	mem() {
 
 		// Create a new memory reference, but make sure it doesn't exist yet.
-		let ref = this.$mem++;
+		let ref = this.#mem++;
 		while (this.memRefs.has(ref)) {
-			ref = this.$mem++;
+			ref = this.#mem++;
 		}
 		this.memRefs.add(ref);
 		return ref;
@@ -119,13 +171,13 @@ export default class CityManager {
 	// Helper function for getting a property from an exemplar, taking into
 	// account the inheritance chain. It's the index that is actually 
 	// responsible for this though.
-	getProperty(file, key) {
+	getProperty<K extends Key>(file: Exemplar, key: K) {
 		return this.index.getProperty(file, key);
 	}
 
 	// ## getPropertyValue(file, prop)
 	// Returns the direct value for the given property.
-	getPropertyValue(file, key) {
+	getPropertyValue<K extends Key>(file: Exemplar, key: K) {
 		return this.index.getPropertyValue(file, key);
 	}
 
@@ -135,14 +187,14 @@ export default class CityManager {
 	// exemplar, which means it only works for *ploppable* buildings. For 
 	// growable buildings the process is different, in that case you have to 
 	// use the "grow" method.
-	plop(opts = {}) {
+	plop(opts: PlopOptions) {
 
 		// (1) First of all we need to find the T10 exemplar file with the 
 		// information to plop the lot. Most of the time this resides in an 
 		// .sc4lot file, but it doesn't have to.
 		let { tgi, building } = opts;
 		if (!building && tgi) {
-			building = this.index.find(tgi);
+			building = this.index.find(tgi as any) as Entry<Exemplar>;
 			if (!building) {
 				throw new Error(
 					`Exemplar ${ JSON.stringify(tgi) } not found!`,
@@ -155,8 +207,8 @@ export default class CityManager {
 		// growable buildings. Apparently ploppable buildings start from a 
 		// building exemplar and then we can look up according 
 		// LotConfiguration exemplar.
-		let file = building.read();
-		if (this.getPropertyValue(file, ExemplarType) !== Buildings) {
+		let file = building!.read();
+		if (this.getPropertyValue(file, 'ExemplarType') !== Property.ExemplarType.Buildings) {
 			throw new Error([
 				'The exemplar is not a building exemplar!',
 				'The `.plop()` function expects a ploppable building exemplar!',
@@ -167,13 +219,16 @@ export default class CityManager {
 		// LotResourceKey & then based on that find the appropriate Building 
 		// exemplar. Note that we currently have no other choice than finding 
 		// everything with the same instance ID...
-		let IID = this.getPropertyValue(file, LotResourceKey);
-		let lotExemplar = this.findExemplarOfType(IID, LotConfigurations);
+		let IID = this.getPropertyValue(file, Property.LotResourceKey)!;
+		let lotExemplar = this.findExemplarOfType(
+			IID,
+			Property.ExemplarType.LotConfigurations
+		)!;
 
 		// Cool, we have both the building & the lot exemplar. Create the lot.
 		this.build({
 			lot: lotExemplar,
-			building,
+			building: building!,
 			x: opts.x,
 			z: opts.z,
 			orientation: opts.orientation,
@@ -186,9 +241,11 @@ export default class CityManager {
 	// from a *Lot Configurations* exemplar, not a ploppable building exemplar 
 	// - which is how the game does it. From then on the logic is pretty much 
 	// the same.
-	grow(opts) {
+	grow(opts: GrowOptions) {
 
-		let { lot = this.index.find(opts.tgi) } = opts;
+		let {
+			lot = this.index.find(opts.tgi as any) as Entry<Exemplar>,
+		} = opts;
 		if (!lot) {
 			throw new Error(
 				`Exemplar ${ JSON.stringify(opts.tgi) } not found!`,
@@ -197,7 +254,7 @@ export default class CityManager {
 
 		// Ensure that the exemplar that was specified.
 		let props = lot.read();
-		if (+props.value(ExemplarType) !== LotConfigurations) {
+		if (props.get(Property.ExemplarType) !== Property.ExemplarType.LotConfigurations) {
 			throw new Error([
 				'The exemplar is not a lot configurations exemplar!',
 				'The `.grow()` function expects a lot exemplar!',
@@ -209,7 +266,7 @@ export default class CityManager {
 		// random building from the family.
 		let { building } = opts;
 		if (!building) {
-			let IIDs = props.lotObjects.find(({ type }) => type === 0x00).IIDs;
+			let { IIDs } = props.lotObjects.find(obj => obj.type === 0x00)!;
 			let IID = rand(IIDs);
 			building = this.findExemplarOfType(IID, 0x02);
 			if (!building) {
@@ -243,7 +300,7 @@ export default class CityManager {
 	// or `.grow()` methods instead. It requires a lot exemplar and a building 
 	// exemplar to be specified. It's the `.plop()` and `.grow()` methods that 
 	// are responsible for deciding what building will be inserted.
-	build(opts) {
+	build(opts: BuildOptions) {
 
 		// First of all create the lot record & insert it into the city.
 		let {
@@ -303,7 +360,7 @@ export default class CityManager {
 	// ## zone(opts)
 	// The function responsible for creating RCI zones. Note that we **don't** 
 	// use the createLot function underneath as that
-	zone(opts) {
+	zone(opts: ZoneOptions) {
 		let {
 			x = 0,
 			z = 0,
@@ -348,7 +405,7 @@ export default class CityManager {
 		lots.push(lot);
 
 		// Put in the zone developer file & update the Zone View Sim Grid.
-		let grid = dbpf.getSimGrid(SimGrid.ZoneData);
+		let grid = dbpf.getSimGrid(SimGrid.ZoneData)!;
 		for (let x = lot.minX; x <= lot.maxX; x++) {
 			for (let z = lot.minZ; z <= lot.maxZ; z++) {
 				grid.set(x, z, zoneType);
@@ -367,7 +424,13 @@ export default class CityManager {
 
 	// ## createLot(opts)
 	// Creates a new lot object from the given options when plopping a lot.
-	createLot(opts) {
+	createLot(opts: {
+		exemplar: Entry<Exemplar>;
+		building: Entry<Exemplar>;
+		x: number;
+		z: number;
+		orientation: Orientation;
+	}) {
 
 		// Read in the size of the lot because we'll still need it.
 		let { dbpf } = this;
@@ -376,20 +439,20 @@ export default class CityManager {
 		let file = exemplar.read();
 		let [width, depth] = this.getPropertyValue(
 			file,
-			LotConfigPropertySize,
-		);
+			Property.LotConfigPropertySize,
+		)!;
 
 		// Determine the zone type.
 		let zoneTypes = this.getPropertyValue(
 			file,
-			LotConfigPropertyZoneTypes,
-		);
+			Property.LotConfigPropertyZoneTypes,
+		)!;
 		let zoneType = zoneTypes[0] || 0x0f;
 
 		// Determine the zoneWealth as well. Note that this is to be taken 
 		// **from the building**.
 		let buildingFile = building.read();
-		let zoneWealth = this.getPropertyValue(buildingFile, Wealth);
+		let zoneWealth = this.getPropertyValue(buildingFile, Property.Wealth);
 
 		// Cool, we can now create a new lot entry. Note that we will need to 
 		// take into account the
@@ -429,7 +492,7 @@ export default class CityManager {
 		// Now put the lot in the zone developer file as well. TODO: We should 
 		// actually check first and ensure that no building exists yet here!
 		let zones = dbpf.zoneDeveloper;
-		let grid = dbpf.getSimGrid(SimGrid.ZoneData);
+		let grid = dbpf.getSimGrid(SimGrid.ZoneData)!;
 		for (let x = lot.minX; x <= lot.maxX; x++) {
 			for (let z = lot.minZ; z <= lot.maxZ; z++) {
 				zones.cells[x][z] = new Pointer(lot);
@@ -449,16 +512,16 @@ export default class CityManager {
 
 	// ## createBuilding(opts)
 	// Creates a new building record and inserts it into the savegame.
-	createBuilding(opts) {
+	createBuilding(opts: CreateBuildingOptions) {
 		let { lot, lotObject, exemplar } = opts;
 		let file = exemplar.read();
-		let [, height] = this.getPropertyValue(file, OccupantSize);
+		let [, height] = this.getPropertyValue(file, Property.OccupantSize)!;
 		let { orientation, y } = lotObject;
 
 		// Create the building.
 		let { terrain } = this.dbpf;
 		let { minX, maxX, minZ, maxZ } = position(lotObject, lot);
-		let yPos = terrain.query(0.5*(minX + maxX), 0.5*(minZ + maxZ));
+		let yPos = terrain!.query(0.5*(minX + maxX), 0.5*(minZ + maxZ));
 		let building = new Building({
 			mem: this.mem(),
 
@@ -503,7 +566,10 @@ export default class CityManager {
 	// ## createProp(opts)
 	// Creates a new prop record in and inserts it into the save game. Takes 
 	// into account the position it should take up in a lot.
-	createProp({ lot, lotObject }) {
+	createProp({ lot, lotObject }: {
+		lot: Lot;
+		lotObject: LotObject;
+	}) {
 
 		// Note: in contrast to the building, we don't know yet what prop 
 		// we're going to insert if we're dealing with a prop family. As such 
@@ -519,12 +585,12 @@ export default class CityManager {
 
 		// Get the dimensions of the prop bounding box.
 		let file = exemplar.read();
-		let [, height] = this.getPropertyValue(file, OccupantSize);
+		let [, height] = this.getPropertyValue(file, Property.OccupantSize)!;
 
 		// Create the prop & position correctly.
 		let { terrain } = this.dbpf;
 		let { minX, maxX, minZ, maxZ } = position(lotObject, lot);
-		let yPos = terrain.query(0.5*(minX + maxX), 0.5*(minZ + maxZ));
+		let yPos = terrain!.query(0.5*(minX + maxX), 0.5*(minZ + maxZ));
 		let prop = new Prop({
 			mem: this.mem(),
 
@@ -555,7 +621,7 @@ export default class CityManager {
 		props.push(prop);
 
 		// Put the prop in the index.
-		this.addToItemIndex(prop, FileType.Prop, lotObject);
+		this.addToItemIndex(prop, FileType.Prop);
 
 		// Update the COM serializer and we're done.
 		let com = dbpf.COMSerializer;
@@ -567,7 +633,10 @@ export default class CityManager {
 	// ## createTexture(opts)
 	// Creates a texture entry in the BaseTexture file of the city for the 
 	// given lot.
-	createTexture(opts) {
+	createTexture(opts: {
+		lot: Lot;
+		textures: LotObject[];
+	}) {
 
 		// Create a new texture instance and copy some lot properties in it.
 		let { lot, textures } = opts;
@@ -632,17 +701,17 @@ export default class CityManager {
 	// ## addToItemIndex(obj)
 	// Helper function for adding the given object - that exposes the tract 
 	// coordinates - to the item index.
-	addToItemIndex(obj, type = obj.type) {
+	addToItemIndex(obj: SavegameObject, type: number) {
 		this.dbpf.itemIndex.add(obj, type);
 	}
 
 	// ## findExemplarOfType(IID, type)
 	// Helper function that can find an exemplar with the given instance of 
 	// the given type. It will make use of the families we have as well.
-	findExemplarOfType(IID, type) {
+	findExemplarOfType(IID: number, type: number) {
 		let { index } = this;
 		let family = index.family(IID);
-		const filter = entry => {
+		const filter = (entry: Entry<Exemplar>) => {
 			let file = entry.read();
 			return index.getPropertyValue(file, 0x10) === type;
 		};
@@ -668,8 +737,8 @@ export default class CityManager {
 		const { city } = this;
 		const index = city.itemIndex;
 		const com = city.COMSerializer;
-		const clear = type => {
-			let file = city.readByType(type);
+		const clear = (type: ArrayFileTypeId & SavegameFileTypeId) => {
+			let file = city.readByType(type) as SavegameObject[];
 			if (file) {
 				file.length = 0;
 				index.rebuild(type, file);
@@ -687,8 +756,8 @@ export default class CityManager {
 		city.zoneDeveloper.clear();
 
 		// Clear some simgrids.
-		city.getSimGrid(SimGrid.ZoneData).clear();
-		city.getSimGrid(SimGrid.Power).clear();
+		city.getSimGrid(SimGrid.ZoneData)?.clear();
+		city.getSimGrid(SimGrid.Power)?.clear();
 
 	}
 
@@ -697,7 +766,7 @@ export default class CityManager {
 // ## setTract(obj)
 // Helper function for setting the correct "Tract" values in the given object 
 // based on its bounding box.
-function setTract(obj) {
+function setTract(obj: SavegameObject) {
 	const xSize = 16 * 2**obj.xTractSize;
 	const zSize = 16 * 2**obj.zTractSize;
 	obj.xMinTract = Math.max(64, 64 + Math.floor(obj.minX / xSize));
@@ -711,7 +780,11 @@ function setTract(obj) {
 // **local** lot coordinates into global **city** coordinates. Note that local 
 // lot coordinates use an origin in the bottom-left corner of the lot with an 
 // y axis that is going up. This means that we'll need to invert properly!
-function orient([x, y], lot, opts = {}) {
+function orient(
+	[x, y]: [number, number],
+	lot: Lot,
+	opts: { bare?: boolean } = {},
+): [number, number] {
 	let { width, depth } = lot;
 
 	// First of all we need to swap because orientation 0 in the city is "up", 
@@ -749,7 +822,7 @@ function orient([x, y], lot, opts = {}) {
 // ## position(lotObject, lot)
 // Returns the rectangle we need to position the given lotObject on, taken 
 // into account it's positioned on the given lot.
-function position(lotObject, lot) {
+function position(lotObject: LotObject, lot: Lot) {
 	let { minX, maxX, minZ, maxZ } = lotObject;
 	[minX, minZ] = orient([minX, minZ], lot);
 	[maxX, maxZ] = orient([maxX, maxZ], lot);
@@ -764,6 +837,6 @@ function position(lotObject, lot) {
 
 // ## rand(arr)
 // Helper function that randomly selects a value from a given array.
-function rand(arr) {
+function rand<T>(arr: T[]): T {
 	return arr[Math.random()*arr.length | 0];
 }

--- a/src/api/pipe-manager.ts
+++ b/src/api/pipe-manager.ts
@@ -1,4 +1,5 @@
 // # pipe-manager.js
+import Box3 from 'src/core/box3.js';
 import Context from './city-context.js';
 import {
 	Pipe,
@@ -199,10 +200,7 @@ export default class PipeManager {
 				mem: this.ctx.mem(),
 				x: x+8,
 				z: z+8,
-				xMin: x,
-				xMax: x+16,
-				zMin: z,
-				zMax: z+16,
+				bbox: new Box3([x, 0, z], [x+16, 0, z+16]),
 				xTile: i,
 				zTile: j,
 			});
@@ -224,8 +222,8 @@ export default class PipeManager {
 					cornerValues.push(h);
 				}
 			}
-			pipe.yMax = Math.max(...cornerValues);
-			pipe.yMin = Math.min(...map.contour(i, j));
+			pipe.bbox.maxY = Math.max(...cornerValues);
+			pipe.bbox.minY = Math.min(...map.contour(i, j));
 
 			// Set the bottom vertices & bottom texture.
 			for (let i = 0; i < 2; i++) {

--- a/src/api/pipe-manager.ts
+++ b/src/api/pipe-manager.ts
@@ -1,5 +1,4 @@
 // # pipe-manager.js
-import Box3 from 'src/core/box3.js';
 import Context from './city-context.js';
 import {
 	Pipe,
@@ -7,8 +6,10 @@ import {
 	Color,
 	Pointer,
 	FileType,
+	Box3,
 	type Savegame,
 	type TerrainMap,
+    Vector3,
 } from 'sc4/core';
 
 // Bit flags of what connections are enabled. Based on those sides we'll also 
@@ -198,13 +199,13 @@ export default class PipeManager {
 			// Create the pipe tile and position it correctly first.
 			let pipe = new Pipe({
 				mem: this.ctx.mem(),
-				x: x+8,
-				z: z+8,
+				position: new Vector3(x+8, 0, z+8),
 				bbox: new Box3([x, 0, z], [x+16, 0, z+16]),
 				xTile: i,
 				zTile: j,
 			});
-			pipe.yModel = pipe.y = map.query(pipe.x, pipe.z)-1.4;
+			let pos = pipe.position;
+			pipe.yModel = pos.y = map.query(pos.x, pos.z)-1.4;
 
 			// Set the heights at the corner of the terrain. Obviously we we 
 			// need the actual *terrain* coordinates here, not the egalized 
@@ -300,7 +301,7 @@ export default class PipeManager {
 
 			// Insert the prop model at the correct position and then rotate 
 			// into place based on the orientation we've set on the tile.
-			pipe.matrix.position = [pipe.x, pipe.y, pipe.z];
+			pipe.matrix.position = pipe.position;
 			if (pipe.orientation === 1) {
 				pipe.matrix.ex = [0, 0, 1];
 				pipe.matrix.ez = [-1, 0, 0];

--- a/src/api/pipe-manager.ts
+++ b/src/api/pipe-manager.ts
@@ -204,8 +204,6 @@ export default class PipeManager {
 				xTile: i,
 				zTile: j,
 			});
-			pipe.xMinTract = pipe.xMaxTract = 0x40 + Math.floor(i/4);
-			pipe.zMinTract = pipe.zMaxTract = 0x40 + Math.floor(j/4);
 			pipe.yModel = pipe.y = map.query(pipe.x, pipe.z)-1.4;
 
 			// Set the heights at the corner of the terrain. Obviously we we 
@@ -224,6 +222,7 @@ export default class PipeManager {
 			}
 			pipe.bbox.maxY = Math.max(...cornerValues);
 			pipe.bbox.minY = Math.min(...map.contour(i, j));
+			pipe.tract.update(pipe);
 
 			// Set the bottom vertices & bottom texture.
 			for (let i = 0; i < 2; i++) {

--- a/src/api/pipe-manager.ts
+++ b/src/api/pipe-manager.ts
@@ -221,8 +221,8 @@ export default class PipeManager {
 					cornerValues.push(h);
 				}
 			}
-			pipe.bbox.maxY = Math.max(...cornerValues);
-			pipe.bbox.minY = Math.min(...map.contour(i, j));
+			pipe.bbox.max.y = Math.max(...cornerValues);
+			pipe.bbox.min.y = Math.min(...map.contour(i, j));
 			pipe.tract.update(pipe);
 
 			// Set the bottom vertices & bottom texture.

--- a/src/api/plop-all-lots.ts
+++ b/src/api/plop-all-lots.ts
@@ -18,7 +18,7 @@ type PlopAllLotsOptions = {
 	plugins?: folder;
 	logger?: Logger;
 	random?: number | boolean;
-	city: Savegame | string;
+	city: string;
 	clear?: boolean;
 	bbox?: [number, number, number, number];
 	save?: boolean;
@@ -108,7 +108,7 @@ export default async function plopAllLots(opts: PlopAllLotsOptions)
 		if (opts.backup && city.file) {
 			await opts.backup(city.file, opts);
 		}
-		const { output = city.file } = opts;
+		const { output = city.file! } = opts;
 		await city.save({ file: output });
 	}
 	return city;

--- a/src/api/skyline.ts
+++ b/src/api/skyline.ts
@@ -147,7 +147,7 @@ export default function skyline(opts: SkylineOptions) {
 
 			// Cool, we got space left to plop the lot. Just do it baby.
 			city.grow({
-				exemplar: lot,
+				lot,
 				x,
 				z,
 				orientation,

--- a/src/api/test/plop-all-test.ts
+++ b/src/api/test/plop-all-test.ts
@@ -21,11 +21,11 @@ describe('The plopall api function', function() {
 			bbox: [16, 2, 32, 32],
 		}) as Savegame;
 
-		let [building] = dbpf.buildings;
-		expect(building.maxX).to.be.at.least(16*16)
-		expect(building.maxX).to.be.at.most((16+2)*16);
-		expect(building.maxZ).to.be.at.least(2*16);
-		expect(building.maxZ).to.be.at.most((2+3)*16);
+		let [{ bbox }] = dbpf.buildings;
+		expect(bbox.maxX).to.be.at.least(16*16)
+		expect(bbox.maxX).to.be.at.most((16+2)*16);
+		expect(bbox.maxZ).to.be.at.least(2*16);
+		expect(bbox.maxZ).to.be.at.most((2+3)*16);
 
 	});
 

--- a/src/core/box-3.ts
+++ b/src/core/box-3.ts
@@ -20,6 +20,8 @@ export default class Box3 extends Array<Vector3> {
 		super(new Vector3(...min), new Vector3(...max));
 	}
 
+	get min(): Vector3 { return this[0]; }
+	get max(): Vector3 { return this[1]; }
 	get minX(): meters { return this[0][0]; }
 	get minY(): meters { return this[0][1]; }
 	get minZ(): meters { return this[0][2]; }
@@ -34,21 +36,13 @@ export default class Box3 extends Array<Vector3> {
 	set maxY(value: meters) { this[1][1] = value; }
 	set maxZ(value: meters) { this[1][2] = value; }
 
-	// ## move()
-	// Moves the bbox with the given vector.
-	move(offset: Vector3): this;
-	move(dx: meters, dy: meters, dz: meters): this;
-	move(dx: Vector3 | meters = 0, dy: meters = 0, dz: meters = 0): this {
-		if (Array.isArray(dx)) {
-			[dx = 0, dy = 0, dz = 0] = dx;
-		}
-		this.minX += dx;
-		this.maxX += dx;
-		this.minY += dy;
-		this.maxY += dy;
-		this.minZ += dz;
-		this.maxZ += dz;
-		return this;
+	// ## translate(offset)
+	// Translates the box with the given vector, and returns a *new* box.
+	translate(offset: Vector3Like) {
+		return new Box3(
+			this.min.add(offset),
+			this.max.add(offset),
+		);
 	}
 
 	// ## parse(rs)

--- a/src/core/box-3.ts
+++ b/src/core/box-3.ts
@@ -2,18 +2,22 @@
 import type { meters } from 'sc4/types';
 import type Stream from './stream.js';
 import type WriteBuffer from './write-buffer.js';
+import Vector3 from './vector-3.js';
+import type { Vector3Like } from './vector-3.js';
 
 // # Bbox
 // A class for representing a bounding box of an occupant object. A lot of the 
 // savegame data structures include minX, minY, minZ, maxX, maxY, maxZ, so it 
 // makes sense to put it in a separate data structure, especially because it 
 // makes parsing & serializing them easier to read.
-type Vector3 = [x: meters, y: meters, z: meters];
 export default class Box3 extends Array<Vector3> {
 	
 	// ## constructor(min, max)
-	constructor(min: Vector3 = [0, 0, 0], max: Vector3 = [0, 0, 0]) {
-		super(min, max);
+	constructor(
+		min: Vector3Like = [0, 0, 0],
+		max: Vector3Like = [0, 0, 0],
+	) {
+		super(new Vector3(...min), new Vector3(...max));
 	}
 
 	get minX(): meters { return this[0][0]; }
@@ -49,20 +53,16 @@ export default class Box3 extends Array<Vector3> {
 
 	// ## parse(rs)
 	parse(rs: Stream) {
-		this[0] = [rs.float(), rs.float(), rs.float()];
-		this[1] = [rs.float(), rs.float(), rs.float()];
+		this[0] = rs.vector3();
+		this[1] = rs.vector3();
 		return this;
 	}
 
 	// ## write(ws)
 	write(ws: WriteBuffer) {
 		let [min, max] = this;
-		ws.float(min[0]);
-		ws.float(min[1]);
-		ws.float(min[2]);
-		ws.float(max[0]);
-		ws.float(max[1]);
-		ws.float(max[2]);
+		ws.vector3(min);
+		ws.vector3(max);
 		return this;
 	}
 

--- a/src/core/box-3.ts
+++ b/src/core/box-3.ts
@@ -1,4 +1,4 @@
-// # bbox.ts
+// # box-3.ts
 import type { meters } from 'sc4/types';
 import type Stream from './stream.js';
 import type WriteBuffer from './write-buffer.js';

--- a/src/core/box3.ts
+++ b/src/core/box3.ts
@@ -1,0 +1,69 @@
+// # bbox.ts
+import type { meters } from 'sc4/types';
+import type Stream from './stream.js';
+import type WriteBuffer from './write-buffer.js';
+
+// # Bbox
+// A class for representing a bounding box of an occupant object. A lot of the 
+// savegame data structures include minX, minY, minZ, maxX, maxY, maxZ, so it 
+// makes sense to put it in a separate data structure, especially because it 
+// makes parsing & serializing them easier to read.
+type Vector3 = [x: meters, y: meters, z: meters];
+export default class Box3 extends Array<Vector3> {
+	
+	// ## constructor(min, max)
+	constructor(min: Vector3 = [0, 0, 0], max: Vector3 = [0, 0, 0]) {
+		super(min, max);
+	}
+
+	get minX(): meters { return this[0][0]; }
+	get minY(): meters { return this[0][1]; }
+	get minZ(): meters { return this[0][2]; }
+	get maxX(): meters { return this[1][0]; }
+	get maxY(): meters { return this[1][1]; }
+	get maxZ(): meters { return this[1][2]; }
+
+	set minX(value: meters) { this[0][0] = value; }
+	set minY(value: meters) { this[0][1] = value; }
+	set minZ(value: meters) { this[0][2] = value; }
+	set maxX(value: meters) { this[1][0] = value; }
+	set maxY(value: meters) { this[1][1] = value; }
+	set maxZ(value: meters) { this[1][2] = value; }
+
+	// ## move()
+	// Moves the bbox with the given vector.
+	move(offset: Vector3): this;
+	move(dx: meters, dy: meters, dz: meters): this;
+	move(dx: Vector3 | meters = 0, dy: meters = 0, dz: meters = 0): this {
+		if (Array.isArray(dx)) {
+			[dx = 0, dy = 0, dz = 0] = dx;
+		}
+		this.minX += dx;
+		this.maxX += dx;
+		this.minY += dy;
+		this.maxY += dy;
+		this.minZ += dz;
+		this.maxZ += dz;
+		return this;
+	}
+
+	// ## parse(rs)
+	parse(rs: Stream) {
+		this[0] = [rs.float(), rs.float(), rs.float()];
+		this[1] = [rs.float(), rs.float(), rs.float()];
+		return this;
+	}
+
+	// ## write(ws)
+	write(ws: WriteBuffer) {
+		let [min, max] = this;
+		ws.float(min[0]);
+		ws.float(min[1]);
+		ws.float(min[2]);
+		ws.float(max[0]);
+		ws.float(max[1]);
+		ws.float(max[2]);
+		return this;
+	}
+
+}

--- a/src/core/building.ts
+++ b/src/core/building.ts
@@ -5,6 +5,7 @@ import SGProp from './sgprop.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type Stream from './stream.js';
 import type { ConstructorOptions } from 'sc4/types';
+import Box3 from './box3.js';
 
 // # Building()
 // Represents a single building from the building file.
@@ -30,12 +31,7 @@ export default class Building {
 	TID = 0x00000000;
 	IID = 0x00000000;
 	IID1 = 0x00000000;
-	minX = 0;
-	minY = 0;
-	minZ = 0;
-	maxX = 0;
-	maxY = 0;
-	maxZ = 0;
+	bbox = new Box3();
 	orientation = 0x00;
 	scaffold = 0x01;
 
@@ -52,21 +48,13 @@ export default class Building {
 		if (Array.isArray(dx)) {
 			[dx, dy, dz] = dx;
 		}
-		dx = dx ?? 0;
-		dy = dy ?? 0;
-		dz = dz ?? 0;
-		this.minX += dx;
-		this.maxX += dx;
-		this.minY += dy;
-		this.maxY += dy;
-		this.minZ += dz;
-		this.maxZ += dz;
+		this.bbox.move(dx, dy, dz);
 
 		// Recalculate the tracts. A tract is a 4x4 tile, so 4x16m in length.
-		this.xMinTract = 0x40 + Math.floor(this.minX / 64);
-		this.xMaxTract = 0x40 + Math.floor(this.maxX / 64);
-		this.zMinTract = 0x40 + Math.floor(this.minZ / 64);
-		this.zMaxTract = 0x40 + Math.floor(this.maxZ / 64);
+		this.xMinTract = 0x40 + Math.floor(this.bbox.minX / 64);
+		this.xMaxTract = 0x40 + Math.floor(this.bbox.maxX / 64);
+		this.zMinTract = 0x40 + Math.floor(this.bbox.minZ / 64);
+		this.zMaxTract = 0x40 + Math.floor(this.bbox.maxZ / 64);
 		return this;
 
 	}
@@ -103,12 +91,7 @@ export default class Building {
 		this.IID = rs.dword();
 		this.IID1 = rs.dword();
 		this.unknown2 = rs.byte();
-		this.minX = rs.float();
-		this.minY = rs.float();
-		this.minZ = rs.float();
-		this.maxX = rs.float();
-		this.maxY = rs.float();
-		this.maxZ = rs.float();
+		this.bbox = new Box3().parse(rs);
 		this.orientation = rs.byte();
 		this.scaffold = rs.float();
 
@@ -142,12 +125,7 @@ export default class Building {
 		ws.dword(this.IID);
 		ws.dword(this.IID1);
 		ws.byte(this.unknown2);
-		ws.float(this.minX);
-		ws.float(this.minY);
-		ws.float(this.minZ);
-		ws.float(this.maxX);
-		ws.float(this.maxY);
-		ws.float(this.maxZ);
+		this.bbox.write(ws);
 		ws.byte(this.orientation);
 		ws.float(this.scaffold);
 

--- a/src/core/building.ts
+++ b/src/core/building.ts
@@ -3,10 +3,11 @@ import WriteBuffer from './write-buffer.js';
 import FileType from './file-types.js';
 import SGProp from './sgprop.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
-import type Stream from './stream.js';
-import type { ConstructorOptions } from 'sc4/types';
 import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
+import type Stream from './stream.js';
+import type { ConstructorOptions } from 'sc4/types';
+import type { Vector3Like } from './vector-3.js';
 
 // # Building()
 // Represents a single building from the building file.
@@ -36,16 +37,13 @@ export default class Building {
 		Object.assign(this, opts);
 	}
 
-	// ## move(dx, dy, dz)
+	// ## move(move)
 	// The move vector of the building contains [dx, dy, dz] and should be 
 	// given in meters! This is because apparently the min/max values of the 
 	// building are given in meters as well.
-	move(dx: number | [number, number, number], dy: number, dz: number) {
-		if (Array.isArray(dx)) {
-			[dx, dy, dz] = dx;
-		}
-		this.bbox.move(dx, dy, dz);
-		this.tract.update(this.bbox);
+	move(offset: Vector3Like) {
+		this.bbox = this.bbox.translate(offset);
+		this.tract.update(this);
 		return this;
 	}
 

--- a/src/core/building.ts
+++ b/src/core/building.ts
@@ -125,7 +125,7 @@ export default class Building {
 		ws.dword(this.IID);
 		ws.dword(this.IID1);
 		ws.byte(this.unknown2);
-		this.bbox.write(ws);
+		ws.bbox(this.bbox);
 		ws.byte(this.orientation);
 		ws.float(this.scaffold);
 

--- a/src/core/building.ts
+++ b/src/core/building.ts
@@ -5,7 +5,7 @@ import SGProp from './sgprop.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type Stream from './stream.js';
 import type { ConstructorOptions } from 'sc4/types';
-import Box3 from './box3.js';
+import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
 
 // # Building()

--- a/src/core/flora.ts
+++ b/src/core/flora.ts
@@ -7,7 +7,7 @@ import { kFileType, kFileTypeArray } from './symbols.js';
 import type Stream from './stream.js';
 import type { ConstructorOptions } from 'sc4/types';
 import TractInfo from './tract-info.js';
-import Vector3 from './vector-3.js';
+import { Vector3, type Vector3Like } from './vector-3.js';
 
 // # Flora
 // Represents a single flora item. Note that you want to register 
@@ -38,6 +38,13 @@ export default class Flora {
 
 	constructor(opts?: ConstructorOptions<Flora>) {
 		Object.assign(this, opts);
+	}
+
+	// ## move()
+	move(offset: Vector3Like) {
+		this.position = this.position.add(offset);
+		this.tract.update(this.position);
+		return this;
 	}
 
 	// ## parse(rs)

--- a/src/core/flora.ts
+++ b/src/core/flora.ts
@@ -7,6 +7,7 @@ import { kFileType, kFileTypeArray } from './symbols.js';
 import type Stream from './stream.js';
 import type { ConstructorOptions } from 'sc4/types';
 import TractInfo from './tract-info.js';
+import Vector3 from './vector-3.js';
 
 // # Flora
 // Represents a single flora item. Note that you want to register 
@@ -28,9 +29,7 @@ export default class Flora {
 	TID = 0x00000000;
 	IID = 0x00000000;
 	IID1 = 0x00000000;
-	x = 0;
-	y = 0;
-	z = 0;
+	position = new Vector3();
 	cycleDate = new Date();
 	appearanceDate = new Date();
 	state = 0x00;
@@ -58,9 +57,7 @@ export default class Flora {
 		this.TID = rs.dword();
 		this.IID = rs.dword();
 		this.IID1 = rs.dword();
-		this.x = rs.float();
-		this.y = rs.float();
-		this.z = rs.float();
+		this.position = rs.vector3();
 		this.cycleDate.setTime(getUnixFromJulian(rs.dword()));
 		this.appearanceDate.setTime(getUnixFromJulian(rs.dword()));
 		this.state = rs.byte();
@@ -85,9 +82,7 @@ export default class Flora {
 		ws.dword(this.TID);
 		ws.dword(this.IID);
 		ws.dword(this.IID1);
-		ws.float(this.x);
-		ws.float(this.y);
-		ws.float(this.z);
+		ws.vector3(this.position);
 		ws.dword(getJulianFromUnix(this.cycleDate));
 		ws.dword(getJulianFromUnix(this.appearanceDate));
 		ws.byte(this.state);

--- a/src/core/flora.ts
+++ b/src/core/flora.ts
@@ -6,12 +6,12 @@ import { getUnixFromJulian, getJulianFromUnix } from 'sc4/utils';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type Stream from './stream.js';
 import type { ConstructorOptions } from 'sc4/types';
+import TractInfo from './tract-info.js';
 
 // # Flora
 // Represents a single flora item. Note that you want to register 
 // **Flora.Array** as file for the DBPF files, not the flora class itself!
 export default class Flora {
-
 	static [kFileType] = FileType.Flora;
 	static [kFileTypeArray] = true;
 	crc = 0x00000000;
@@ -22,12 +22,7 @@ export default class Flora {
 	u1 = 0x00;
 	appearance = 0b00001101;
 	u2 = 0x74758926;
-	xMinTract = 0x00;
-	zMinTract = 0x00;
-	xMaxTract = 0x00;
-	zMaxTract = 0x00;
-	xTractSize = 0x0002;
-	zTractSize = 0x0002;
+	tract = new TractInfo();
 	sgprops: SGProp[] = [];
 	GID = 0x00000000;
 	TID = 0x00000000;
@@ -48,7 +43,6 @@ export default class Flora {
 
 	// ## parse(rs)
 	parse(rs: Stream) {
-
 		rs.size();
 		this.crc = rs.dword();
 		this.mem = rs.dword();
@@ -58,21 +52,8 @@ export default class Flora {
 		this.u1 = rs.byte();
 		this.appearance = rs.byte();
 		this.u2 = rs.dword();
-		this.xMinTract = rs.byte();
-		this.zMinTract = rs.byte();
-		this.xMaxTract = rs.byte();
-		this.zMaxTract = rs.byte();
-		this.xTractSize = rs.word();
-		this.zTractSize = rs.word();
-
-		// Read properties.
-		const count = this.sgprops.length = rs.dword();
-		for (let i = 0; i < count; i++) {
-			let prop = this.sgprops[i] = new SGProp();
-			prop.parse(rs);
-		}
-
-		// Read group ids.
+		this.tract = rs.tract();
+		this.sgprops = rs.sgprops();
 		this.GID = rs.dword();
 		this.TID = rs.dword();
 		this.IID = rs.dword();
@@ -85,10 +66,7 @@ export default class Flora {
 		this.state = rs.byte();
 		this.orientation = rs.byte();
 		this.objectId = rs.dword();
-
-		// Done
 		return this;
-
 	}
 
 	// ## toBuffer()
@@ -101,12 +79,7 @@ export default class Flora {
 		ws.byte(this.u1);
 		ws.byte(this.appearance);
 		ws.dword(this.u2);
-		ws.byte(this.xMinTract);
-		ws.byte(this.zMinTract);
-		ws.byte(this.xMaxTract);
-		ws.byte(this.zMaxTract);
-		ws.word(this.xTractSize);
-		ws.word(this.zTractSize);
+		ws.tract(this.tract);
 		ws.array(this.sgprops);
 		ws.dword(this.GID);
 		ws.dword(this.TID);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,6 +14,8 @@ export * from './file-classes.js';
 export { default as Color } from './color.js';
 export { default as Vertex } from './vertex.js';
 export { default as Pointer } from './pointer.js';
+export { default as Vector3 } from './vector-3.js';
+export { default as Box3 } from './box-3.js';
 
 // Export relevant types.
 export type { DBPFOptions, DBPFSaveOptions, DBPFJSON } from './dbpf.js';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -19,7 +19,7 @@ export { default as Pointer } from './pointer.js';
 export type { DBPFOptions, DBPFSaveOptions, DBPFJSON } from './dbpf.js';
 export type {
 	default as Entry,
-		EntryFromType,
+	EntryFromType,
 	EntryJSON,
 } from './dbpf-entry.js';
 export type {
@@ -30,7 +30,9 @@ export type {
 	FileTypeName,
 	DecodedFileTypeId,
 	DecodedFileTypeName,
+	ArrayFileTypeId,
 	SimGridFileType,
+	SavegameFileTypeId,
 } from './types.js';
 
 export type {

--- a/src/core/item-index.ts
+++ b/src/core/item-index.ts
@@ -71,7 +71,7 @@ export default class ItemIndex {
 	// ## rebuild(type, file)
 	// Rebuilds the index so that it puts all entries of the given file in 
 	// their correct tracts.
-	rebuild(type: SavegameTypeId, file: SavegameObject[]) {
+	rebuild(type: number, file: SavegameObject[]) {
 
 		// From now on we need a specific file type because certain arrays might 
 		// be empty, in which case we don't know what type of values the array 

--- a/src/core/item-index.ts
+++ b/src/core/item-index.ts
@@ -4,16 +4,13 @@ import Pointer from './pointer.js';
 import { FileType } from './enums.js';
 import { getClassType } from './helpers.js';
 import { kFileType } from './symbols.js';
-import { type SavegameFileType } from './file-types.js';
-import type { ValueOf } from 'type-fest';
-import type { SavegameObject } from './types.js';
+import type { SavegameObject, SavegameTypeId } from './types.js';
 import type Stream from './stream.js';
 
 const SIZE = 192;
 type CitySize = 1024 | 2048 | 4096;
 type TractSize = 16 | 32 | 64;
 type TileSize = 64 | 128 | 256;
-type SavegameType = ValueOf<typeof SavegameFileType>;
 
 // # ItemIndex
 export default class ItemIndex {
@@ -74,7 +71,7 @@ export default class ItemIndex {
 	// ## rebuild(type, file)
 	// Rebuilds the index so that it puts all entries of the given file in 
 	// their correct tracts.
-	rebuild(type: SavegameType, file: SavegameObject[]) {
+	rebuild(type: SavegameTypeId, file: SavegameObject[]) {
 
 		// From now on we need a specific file type because certain arrays might 
 		// be empty, in which case we don't know what type of values the array 

--- a/src/core/item-index.ts
+++ b/src/core/item-index.ts
@@ -4,7 +4,7 @@ import Pointer from './pointer.js';
 import { FileType } from './enums.js';
 import { getClassType } from './helpers.js';
 import { kFileType } from './symbols.js';
-import type { SavegameObject, SavegameTypeId } from './types.js';
+import type { SavegameObject } from './types.js';
 import type Stream from './stream.js';
 
 const SIZE = 192;

--- a/src/core/lot-base-texture.ts
+++ b/src/core/lot-base-texture.ts
@@ -4,7 +4,7 @@ import { FileType } from './enums.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type { ConstructorOptions } from 'sc4/types';
 import type Stream from './stream.js';
-import Box3 from './box3.js';
+import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
 
 // # LotBaseTexture

--- a/src/core/lot-base-texture.ts
+++ b/src/core/lot-base-texture.ts
@@ -6,6 +6,7 @@ import type { ConstructorOptions } from 'sc4/types';
 import type Stream from './stream.js';
 import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
+import type { Vector3Like } from './vector-3.js';
 
 // # LotBaseTexture
 export default class LotBaseTexture {
@@ -33,19 +34,14 @@ export default class LotBaseTexture {
 	}
 
 	// ## move(dx, dz)
-	move(dx: [number, number] | number, dz: number) {
-		if (Array.isArray(dx)) {
-			[dx, dz] = dx;
-		}
-		dx = dx ?? 0;
-		dz = dz ?? 0;
-		this.bbox.move(dx, 0, dz);
-		this.tract.update(this.bbox);
+	move(offset: Vector3Like) {
+		this.bbox = this.bbox.translate(offset);
+		this.tract.update(this);
 
 		// Move the actual textures.
 		for (let texture of this.textures) {
-			texture.x += dx;
-			texture.z += dz;
+			texture.x += offset[0];
+			texture.z += offset[2];
 		}
 		return this;
 	}

--- a/src/core/lot-base-texture.ts
+++ b/src/core/lot-base-texture.ts
@@ -5,6 +5,7 @@ import { kFileType, kFileTypeArray } from './symbols.js';
 import type { ConstructorOptions } from 'sc4/types';
 import type Stream from './stream.js';
 import Box3 from './box3.js';
+import TractInfo from './tract-info.js';
 
 // # LotBaseTexture
 export default class LotBaseTexture {
@@ -19,12 +20,7 @@ export default class LotBaseTexture {
 	u3 = 0x00;
 	u4 = 0x05;
 	u5 = 0x497f6d9d;
-	xMinTract = 0x40;
-	zMinTract = 0x40;
-	xMaxTract = 0x40;
-	zMaxTract = 0x40;
-	xTractSize = 0x0002;
-	zTractSize = 0x0002;
+	tract = new TractInfo();
 	u6 = 0x00000000;
 	u7 = 0x00000000;
 	u8 = 0x00000000;
@@ -44,12 +40,7 @@ export default class LotBaseTexture {
 		dx = dx ?? 0;
 		dz = dz ?? 0;
 		this.bbox.move(dx, 0, dz);
-
-		// Recalculate the tracts. A tract is a 4x4 tile, so 4x16m in length.
-		this.xMinTract = 0x40 + Math.floor(this.bbox.minX / 64);
-		this.xMaxTract = 0x40 + Math.floor(this.bbox.maxX / 64);
-		this.zMinTract = 0x40 + Math.floor(this.bbox.minZ / 64);
-		this.zMaxTract = 0x40 + Math.floor(this.bbox.maxZ / 64);
+		this.tract.update(this.bbox);
 
 		// Move the actual textures.
 		for (let texture of this.textures) {
@@ -71,12 +62,7 @@ export default class LotBaseTexture {
 		this.u3 = rs.byte();
 		this.u4 = rs.byte();
 		this.u5 = rs.dword();
-		this.xMinTract = rs.byte();
-		this.zMinTract = rs.byte();
-		this.xMaxTract = rs.byte();
-		this.zMaxTract = rs.byte();
-		this.xTractSize = rs.word();
-		this.zTractSize = rs.word();
+		this.tract = rs.tract();
 		this.u6 = rs.dword();
 		this.u7 = rs.dword();
 		this.u8 = rs.dword();
@@ -108,12 +94,7 @@ export default class LotBaseTexture {
 		ws.byte(this.u3);
 		ws.byte(this.u4);
 		ws.dword(this.u5);
-		ws.byte(this.xMinTract);
-		ws.byte(this.zMinTract);
-		ws.byte(this.xMaxTract);
-		ws.byte(this.zMaxTract);
-		ws.word(this.xTractSize);
-		ws.word(this.zTractSize);
+		ws.tract(this.tract);
 		ws.dword(this.u6);
 		ws.dword(this.u7);
 		ws.dword(this.u8);

--- a/src/core/matrix-3.ts
+++ b/src/core/matrix-3.ts
@@ -1,6 +1,6 @@
 // # matrix-3.ts
-import type Stream from "./stream.js";
-import type WriteBuffer from "./write-buffer.js";
+import type Stream from './stream.js';
+import type WriteBuffer from './write-buffer.js';
 
 // # Matrix3
 // Class for representing a 2D transformation matrix.

--- a/src/core/network.ts
+++ b/src/core/network.ts
@@ -8,6 +8,7 @@ import type { byte, dword, float, word } from 'sc4/types';
 import type Stream from './stream.js';
 import type SGProp from './sgprop.js';
 import type { ConstructorOptions } from 'sc4/types';
+import Box3 from './box3.js';
 
 // # Network
 // A class for representing a single network tile.
@@ -48,12 +49,7 @@ export default class Network {
 	southConnection: byte = 0x00;
 	crossing: byte = 0;
 	crossingBytes: Uint8Array = new Uint8Array();
-	xMin: float = 0;
-	xMax: float = 0;
-	yMin: float = 0;
-	yMax: float = 0;
-	zMin: float = 0;
-	zMax: float = 0;
+	bbox = new Box3();
 	u = new Unknown();
 
 	constructor(opts: ConstructorOptions<Network> = {}) {
@@ -117,12 +113,7 @@ export default class Network {
 			this.crossingBytes = rs.read(5);
 		}
 		unknown.bytes(3);
-		this.xMin = rs.float();
-		this.xMax = rs.float();
-		this.yMin = rs.float();
-		this.yMax = rs.float();
-		this.zMin = rs.float();
-		this.zMax = rs.float();
+		this.bbox = new Box3().parse(rs);
 		unknown.bytes(4);
 		repeat(4, () => unknown.dword());
 		unknown.dword();
@@ -170,12 +161,7 @@ export default class Network {
 			ws.write(this.crossingBytes);
 		}
 		unknown.bytes();
-		ws.float(this.xMin);
-		ws.float(this.xMax);
-		ws.float(this.yMin);
-		ws.float(this.yMax);
-		ws.float(this.zMin);
-		ws.float(this.zMax);
+		ws.bbox(this.bbox);
 		unknown.bytes();
 		repeat(4, () => unknown.dword());
 		unknown.dword();

--- a/src/core/network.ts
+++ b/src/core/network.ts
@@ -8,7 +8,7 @@ import type { byte, dword, float, word } from 'sc4/types';
 import type Stream from './stream.js';
 import type SGProp from './sgprop.js';
 import type { ConstructorOptions } from 'sc4/types';
-import Box3 from './box3.js';
+import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
 
 // # Network

--- a/src/core/network.ts
+++ b/src/core/network.ts
@@ -10,6 +10,7 @@ import type SGProp from './sgprop.js';
 import type { ConstructorOptions } from 'sc4/types';
 import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
+import type { Vector3Like } from './vector-3.js';
 
 // # Network
 // A class for representing a single network tile.
@@ -61,6 +62,12 @@ export default class Network {
 		u.dword(0x00000002);
 		u.dword(0x00000000);
 		Object.assign(this, opts);
+	}
+
+	// ## move()
+	move(offset: Vector3Like) {
+		this.bbox = this.bbox.translate(offset);
+		this.tract.update(this);
 	}
 
 	parse(rs: Stream): this {

--- a/src/core/network.ts
+++ b/src/core/network.ts
@@ -9,6 +9,7 @@ import type Stream from './stream.js';
 import type SGProp from './sgprop.js';
 import type { ConstructorOptions } from 'sc4/types';
 import Box3 from './box3.js';
+import TractInfo from './tract-info.js';
 
 // # Network
 // A class for representing a single network tile.
@@ -21,12 +22,7 @@ export default class Network {
 	minor: word = 0x0004;
 	zot: word = 0x0000;
 	appearance: byte = 0x05;
-	xMinTract: byte = 0x00;
-	zMinTract: byte = 0x00;
-	xMaxTract: byte = 0x00;
-	zMaxTract: byte = 0x00;
-	xTractSize: word = 0x0002;
-	zTractSize: word = 0x0002;
+	tract = new TractInfo();
 	sgprops: SGProp[] = [];
 	GID: dword = 0x00000000;
 	TID: dword = 0x00000000;
@@ -79,12 +75,7 @@ export default class Network {
 		unknown.byte();
 		this.appearance = rs.byte();
 		unknown.dword();
-		this.xMinTract = rs.byte();
-		this.zMinTract = rs.byte();
-		this.xMaxTract = rs.byte();
-		this.zMaxTract = rs.byte();
-		this.xTractSize = rs.word();
-		this.zTractSize = rs.word();
+		this.tract = rs.tract();
 		this.sgprops = rs.sgprops();
 		this.GID = rs.dword();
 		this.TID = rs.dword();
@@ -132,12 +123,7 @@ export default class Network {
 		unknown.byte();
 		ws.byte(this.appearance);
 		unknown.dword();
-		ws.byte(this.xMinTract);
-		ws.byte(this.zMinTract);
-		ws.byte(this.xMaxTract);
-		ws.byte(this.zMaxTract);
-		ws.word(this.xTractSize);
-		ws.word(this.zTractSize);
+		ws.tract(this.tract);
 		ws.array(this.sgprops);
 		ws.dword(this.GID);
 		ws.dword(this.TID);

--- a/src/core/pipe.ts
+++ b/src/core/pipe.ts
@@ -10,7 +10,7 @@ import { kFileType, kFileTypeArray } from './symbols.js';
 import type { byte, dword, float, word } from 'sc4/types';
 import type Stream from './stream.js';
 import type { ConstructorOptions } from 'sc4/types';
-import Box3 from './box3.js';
+import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
 
 // # Pipe

--- a/src/core/pipe.ts
+++ b/src/core/pipe.ts
@@ -11,6 +11,7 @@ import type { byte, dword, float, word } from 'sc4/types';
 import type Stream from './stream.js';
 import type { ConstructorOptions } from 'sc4/types';
 import Box3 from './box3.js';
+import TractInfo from './tract-info.js';
 
 // # Pipe
 // Pipe tiles are suprisingly large data structures (usually about 700 bytes). 
@@ -24,12 +25,7 @@ export default class Pipe {
 	minor: word = 0x0003;
 	zot: word = 0x0008;
 	appearance: byte = 0x05;
-	xMinTract: byte = 0x00;
-	zMinTract: byte = 0x00;
-	xMaxTract: byte = 0x00;
-	zMaxTract: byte = 0x00;
-	xTractSize: word = 0x0002;
-	zTractSize: word = 0x0002;
+	tract = new TractInfo();
 	sgprops: SGProp[] = [];
 	GID: dword = 0x00000000;
 	TID: dword = 0x00000000;
@@ -103,12 +99,7 @@ export default class Pipe {
 		unknown.dword();
 		this.appearance = rs.byte();
 		unknown.dword();
-		this.xMinTract = rs.byte();
-		this.zMinTract = rs.byte();
-		this.xMaxTract = rs.byte();
-		this.zMaxTract = rs.byte();
-		this.xTractSize = rs.word();
-		this.zTractSize = rs.word();
+		this.tract = rs.tract();
 		this.sgprops = rs.sgprops();
 		this.GID = rs.dword();
 		this.TID = rs.dword();
@@ -178,12 +169,7 @@ export default class Pipe {
 		unknown.dword();
 		ws.byte(this.appearance);
 		unknown.dword();
-		ws.byte(this.xMinTract);
-		ws.byte(this.zMinTract);
-		ws.byte(this.xMaxTract);
-		ws.byte(this.zMaxTract);
-		ws.word(this.xTractSize);
-		ws.word(this.zTractSize);
+		ws.tract(this.tract);
 		ws.array(this.sgprops);
 		ws.dword(this.GID);
 		ws.dword(this.TID);

--- a/src/core/pipe.ts
+++ b/src/core/pipe.ts
@@ -10,6 +10,7 @@ import { kFileType, kFileTypeArray } from './symbols.js';
 import type { byte, dword, float, word } from 'sc4/types';
 import type Stream from './stream.js';
 import type { ConstructorOptions } from 'sc4/types';
+import Box3 from './box3.js';
 
 // # Pipe
 // Pipe tiles are suprisingly large data structures (usually about 700 bytes). 
@@ -50,12 +51,7 @@ export default class Pipe {
 	northConnection: byte = 0x00;
 	eastConnection: byte = 0x00;
 	southConnection: byte = 0x00;
-	xMin: float = 0;
-	xMax: float = 0;
-	yMin: float = 0;
-	yMax: float = 0;
-	zMin: float = 0;
-	zMax: float = 0;
+	bbox = new Box3();
 	blocks: dword = 0x00000000;
 	sideTextures: SideTextures = new SideTextures();
 	matrix: Matrix = new Matrix();
@@ -138,12 +134,7 @@ export default class Pipe {
 		this.eastConnection = rs.byte();
 		this.southConnection = rs.byte();
 		unknown.dword();
-		this.xMin = rs.float();
-		this.xMax = rs.float();
-		this.yMin = rs.float();
-		this.yMax = rs.float();
-		this.zMin = rs.float();
-		this.zMax = rs.float();
+		this.bbox = new Box3().parse(rs);
 		unknown.bytes(3);
 		unknown.byte();
 		unknown.repeat(4, () => unknown.dword());
@@ -215,12 +206,7 @@ export default class Pipe {
 		ws.byte(this.eastConnection);
 		ws.byte(this.southConnection);
 		unknown.dword();
-		ws.float(this.xMin);
-		ws.float(this.xMax);
-		ws.float(this.yMin);
-		ws.float(this.yMax);
-		ws.float(this.zMin);
-		ws.float(this.zMax);
+		ws.bbox(this.bbox);
 		unknown.bytes();
 		unknown.byte();
 		unknown.repeat(4, () => unknown.dword());

--- a/src/core/pipe.ts
+++ b/src/core/pipe.ts
@@ -1,4 +1,4 @@
-// # pipe-tile.js
+// # pipe-tile.ts
 import { FileType } from './enums.js';
 import Unknown from './unknown.js';
 import WriteBuffer from './write-buffer.js';
@@ -6,12 +6,12 @@ import SGProp from './sgprop.js';
 import Matrix from './matrix.js';
 import Matrix3 from './matrix-3.js';
 import Vertex from './vertex.js';
-import { kFileType, kFileTypeArray } from './symbols.js';
-import type { byte, dword, float, word } from 'sc4/types';
-import type Stream from './stream.js';
-import type { ConstructorOptions } from 'sc4/types';
 import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
+import Vector3 from './vector-3.js';
+import { kFileType, kFileTypeArray } from './symbols.js';
+import type { byte, dword, float, word, ConstructorOptions } from 'sc4/types';
+import type Stream from './stream.js';
 
 // # Pipe
 // Pipe tiles are suprisingly large data structures (usually about 700 bytes). 
@@ -31,9 +31,7 @@ export default class Pipe {
 	TID: dword = 0x00000000;
 	IID: dword = 0x00000000;
 	matrix3: Matrix3 = new Matrix3();
-	x: float = 0;
-	y: float = 0;
-	z: float = 0;
+	position = new Vector3();
 	vertices: [Vertex, Vertex, Vertex, Vertex] = [
 		new Vertex(),
 		new Vertex(),
@@ -106,9 +104,7 @@ export default class Pipe {
 		this.IID = rs.dword();
 		unknown.byte();
 		this.matrix3 = rs.struct(Matrix3);
-		this.x = rs.float();
-		this.y = rs.float();
-		this.z = rs.float();
+		this.position = rs.vector3();
 		this.vertices = [
 			rs.vertex(),
 			rs.vertex(),
@@ -176,9 +172,7 @@ export default class Pipe {
 		ws.dword(this.IID);
 		unknown.byte();
 		ws.write(this.matrix3);
-		ws.float(this.x);
-		ws.float(this.y);
-		ws.float(this.z);
+		ws.vector3(this.position);
 		this.vertices.forEach(v => ws.vertex(v));
 
 		// Reading model starts below.

--- a/src/core/pipe.ts
+++ b/src/core/pipe.ts
@@ -1,4 +1,4 @@
-// # pipe-tile.ts
+// # pipe.ts
 import { FileType } from './enums.js';
 import Unknown from './unknown.js';
 import WriteBuffer from './write-buffer.js';

--- a/src/core/prebuilt-network.ts
+++ b/src/core/prebuilt-network.ts
@@ -6,6 +6,7 @@ import type { byte, dword, float, word } from 'sc4/types';
 import type Stream from './stream.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type SGProp from './sgprop.js';
+import Box3 from './box3.js';
 
 // # PrebuiltNetwork
 // A class that is used for networks that use prebuilt models, such as 
@@ -44,12 +45,7 @@ export default class PrebuiltNetwork {
 	northConnection: byte = 0x00;
 	eastConnection: byte = 0x00;
 	southConnection: byte = 0x00;
-	xMin: float = 0;
-	xMax: float = 0;
-	yMin: float = 0;
-	yMax: float = 0;
-	zMin: float = 0;
-	zMax: float = 0;
+	bbox = new Box3();
 	rest: Uint8Array = new Uint8Array();
 	u = new Unknown();
 
@@ -107,12 +103,7 @@ export default class PrebuiltNetwork {
 		this.eastConnection = rs.byte();
 		this.southConnection = rs.byte();
 		unknown.bytes(7);
-		this.xMin = rs.float();
-		this.xMax = rs.float();
-		this.yMin = rs.float();
-		this.yMax = rs.float();
-		this.zMin = rs.float();
-		this.zMax = rs.float();
+		this.bbox = new Box3().parse(rs);
 		unknown.bytes(4);
 		repeat(4, () => unknown.dword());
 		this.rest = rs.rest();

--- a/src/core/prebuilt-network.ts
+++ b/src/core/prebuilt-network.ts
@@ -7,6 +7,7 @@ import type Stream from './stream.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type SGProp from './sgprop.js';
 import Box3 from './box3.js';
+import TractInfo from './tract-info.js';
 
 // # PrebuiltNetwork
 // A class that is used for networks that use prebuilt models, such as 
@@ -20,10 +21,7 @@ export default class PrebuiltNetwork {
 	minor: word = 0x0008;
 	zot: byte = 0x04;
 	appearance: byte = 0x05;
-	xMinTract: byte = 0x00;
-	zMinTract: byte = 0x00;
-	xMaxTract: byte = 0x00;
-	zMaxTract: byte = 0x00;
+	tract = new TractInfo();
 	xTractSize: word = 0;
 	sgprops: SGProp[] = [];
 	GID: dword = 0x00000000;
@@ -74,12 +72,7 @@ export default class PrebuiltNetwork {
 		unknown.dword();
 		this.appearance = rs.byte();
 		unknown.dword();
-		this.xMinTract = rs.byte();
-		this.zMinTract = rs.byte();
-		this.xMaxTract = rs.byte();
-		this.zMaxTract = rs.byte();
-		this.xTractSize = rs.word();
-		this.zMaxTract = rs.word();
+		this.tract = rs.tract();
 		this.sgprops = rs.sgprops();
 		this.GID = rs.dword();
 		this.TID = rs.dword();

--- a/src/core/prebuilt-network.ts
+++ b/src/core/prebuilt-network.ts
@@ -6,7 +6,7 @@ import type { byte, dword, float, word } from 'sc4/types';
 import type Stream from './stream.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type SGProp from './sgprop.js';
-import Box3 from './box3.js';
+import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
 
 // # PrebuiltNetwork

--- a/src/core/prop.ts
+++ b/src/core/prop.ts
@@ -5,6 +5,7 @@ import { FileType } from './enums.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type { ConstructorOptions } from 'sc4/types';
 import type Stream from './stream.js';
+import Box3 from './box3.js';
 
 type Timing = {
 	interval: number;
@@ -37,12 +38,7 @@ export default class Prop {
 	TID = 0x00000000;
 	IID = 0x00000000;
 	IID1 = 0x00000000;
-	minX = 0;
-	minY = 0;
-	minZ = 0;
-	maxX = 0;
-	maxY = 0;
-	maxZ = 0;
+	bbox = new Box3();
 	orientation = 0x00;
 	state = 0x00;
 	start = 0x00
@@ -81,12 +77,7 @@ export default class Prop {
 		this.TID = rs.dword();
 		this.IID = rs.dword();
 		this.IID1 = rs.dword();
-		this.minX = rs.float();
-		this.minY = rs.float();
-		this.minZ = rs.float();
-		this.maxX = rs.float();
-		this.maxY = rs.float();
-		this.maxZ = rs.float();
+		this.bbox = new Box3().parse(rs);
 		this.orientation = rs.byte();
 		this.state = rs.byte();
 		this.start = rs.byte();
@@ -135,12 +126,7 @@ export default class Prop {
 		ws.dword(this.TID);
 		ws.dword(this.IID);
 		ws.dword(this.IID1);
-		ws.float(this.minX);
-		ws.float(this.minY);
-		ws.float(this.minZ);
-		ws.float(this.maxX);
-		ws.float(this.maxY);
-		ws.float(this.maxZ);
+		ws.bbox(this.bbox);
 		ws.byte(this.orientation);
 		ws.byte(this.state);
 		ws.byte(this.start);

--- a/src/core/prop.ts
+++ b/src/core/prop.ts
@@ -6,6 +6,7 @@ import { kFileType, kFileTypeArray } from './symbols.js';
 import type { ConstructorOptions } from 'sc4/types';
 import type Stream from './stream.js';
 import Box3 from './box3.js';
+import TractInfo from './tract-info.js';
 
 type Timing = {
 	interval: number;
@@ -27,12 +28,7 @@ export default class Prop {
 	unknown1 = 0x00;
 	appearance = 0b00000101;
 	unknown2 = 0xA823821E;
-	xMinTract = 0x00;
-	zMinTract = 0x00;
-	xMaxTract = 0x00;
-	zMaxTract = 0x00;
-	xTractSize = 0x0002;
-	zTractSize = 0x0002;
+	tract = new TractInfo();
 	sgprops: SGProp[] = [];
 	GID = 0x00000000;
 	TID = 0x00000000;
@@ -66,18 +62,13 @@ export default class Prop {
 		this.unknown1 = rs.byte();
 		this.appearance = rs.byte();
 		this.unknown2 = rs.dword();
-		this.xMinTract = rs.byte();
-		this.zMinTract = rs.byte();
-		this.xMaxTract = rs.byte();
-		this.zMaxTract = rs.byte();
-		this.xTractSize = rs.word();
-		this.zTractSize = rs.word();
+		this.tract = rs.tract();
 		this.sgprops = rs.sgprops();
 		this.GID = rs.dword();
 		this.TID = rs.dword();
 		this.IID = rs.dword();
 		this.IID1 = rs.dword();
-		this.bbox = new Box3().parse(rs);
+		this.bbox = rs.bbox();
 		this.orientation = rs.byte();
 		this.state = rs.byte();
 		this.start = rs.byte();
@@ -115,12 +106,7 @@ export default class Prop {
 		ws.byte(this.unknown1);
 		ws.byte(this.appearance);
 		ws.dword(this.unknown2);
-		ws.byte(this.xMinTract);
-		ws.byte(this.zMinTract);
-		ws.byte(this.xMaxTract);
-		ws.byte(this.zMaxTract);
-		ws.word(this.xTractSize);
-		ws.word(this.zTractSize);
+		ws.tract(this.tract);
 		ws.array(this.sgprops);
 		ws.dword(this.GID);
 		ws.dword(this.TID);

--- a/src/core/prop.ts
+++ b/src/core/prop.ts
@@ -7,6 +7,7 @@ import type { ConstructorOptions } from 'sc4/types';
 import type Stream from './stream.js';
 import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
+import type { Vector3Like } from './vector-3.js';
 
 type Timing = {
 	interval: number;
@@ -48,6 +49,12 @@ export default class Prop {
 	// ## constructor(opts)
 	constructor(opts?: ConstructorOptions<Prop>) {
 		Object.assign(this, opts);
+	}
+
+	// ## move()
+	move(offset: Vector3Like) {
+		this.bbox = this.bbox.translate(offset);
+		this.tract.update(this);
 	}
 
 	// ## parse(rs)

--- a/src/core/prop.ts
+++ b/src/core/prop.ts
@@ -5,7 +5,7 @@ import { FileType } from './enums.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import type { ConstructorOptions } from 'sc4/types';
 import type Stream from './stream.js';
-import Box3 from './box3.js';
+import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
 
 type Timing = {

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -22,6 +22,7 @@ import type {
 } from 'sc4/types';
 import type { Class } from 'type-fest';
 import type { FileTypeId } from './types.js';
+import Box3 from './box3.js';
 
 type StreamOptions = Uint8Array | ArrayBuffer | Stream | SmartBufferOptions;
 
@@ -136,6 +137,14 @@ export default class Stream extends SmartBuffer {
 		let vertex = new Vertex();
 		vertex.parse(this);
 		return vertex;
+	}
+
+	// ## bbox()
+	// Reads in a bounding box from the stream.
+	bbox() {
+		let bbox = new Box3();
+		bbox.parse(this);
+		return bbox;
 	}
 
 	// Helper function for reading in an array. We first read in the length 

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -4,6 +4,7 @@ import Pointer from './pointer.js';
 import SGProp from './sgprop.js';
 import Color from './color.js';
 import Vertex from './vertex.js';
+import TractInfo from './tract-info.js';
 import type {
     byte,
     double,
@@ -137,6 +138,14 @@ export default class Stream extends SmartBuffer {
 		let vertex = new Vertex();
 		vertex.parse(this);
 		return vertex;
+	}
+
+	// ## tract()
+	// Reads in a TractInfo object from the stream.
+	tract() {
+		let tract = new TractInfo();
+		tract.parse(this);
+		return tract;
 	}
 
 	// ## bbox()

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -23,7 +23,7 @@ import type {
 } from 'sc4/types';
 import type { Class } from 'type-fest';
 import type { FileTypeId } from './types.js';
-import Box3 from './box3.js';
+import Box3 from './box-3.js';
 import Vector3 from './vector-3.js';
 
 type StreamOptions = Uint8Array | ArrayBuffer | Stream | SmartBufferOptions;

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -24,6 +24,7 @@ import type {
 import type { Class } from 'type-fest';
 import type { FileTypeId } from './types.js';
 import Box3 from './box3.js';
+import Vector3 from './vector-3.js';
 
 type StreamOptions = Uint8Array | ArrayBuffer | Stream | SmartBufferOptions;
 
@@ -119,6 +120,14 @@ export default class Stream extends SmartBuffer {
 		if (address === 0x00000000) return null;
 		let type = this.dword();
 		return new Pointer(type, address);
+	}
+
+	// ## vector3()
+	// Helper function for reading in a 3D vector object.
+	vector3() {
+		let v = new Vector3();
+		v.parse(this);
+		return v;
 	}
 
 	// # color()

--- a/src/core/test/item-index-test.ts
+++ b/src/core/test/item-index-test.ts
@@ -2,7 +2,6 @@
 import { expect } from 'chai';
 import fs from '#test/fs.js';
 import { DBPF, FileType, ItemIndex } from 'sc4/core';
-import { hex } from 'sc4/utils';
 import { resource } from '#test/files.js';
 import { compareUint8Arrays } from 'uint8array-extras';
 
@@ -53,6 +52,8 @@ describe('An item index subfile', function() {
 				xMaxTract: 0x42,
 				zMinTract: 0x44,
 				zMaxTract: 0x45,
+				xTractSize: 0x02,
+				zTractSize: 0x02,
 			},
 		];
 

--- a/src/core/test/item-index-test.ts
+++ b/src/core/test/item-index-test.ts
@@ -4,6 +4,7 @@ import fs from '#test/fs.js';
 import { DBPF, FileType, ItemIndex } from 'sc4/core';
 import { resource } from '#test/files.js';
 import { compareUint8Arrays } from 'uint8array-extras';
+import TractInfo from '../tract-info.js';
 
 describe('An item index subfile', function() {
 
@@ -48,12 +49,7 @@ describe('An item index subfile', function() {
 				[Symbol.for('sc4.type')]: type,
 				parse() {},
 				mem: 0xffffffff,
-				xMinTract: 0x40,
-				xMaxTract: 0x42,
-				zMinTract: 0x44,
-				zMaxTract: 0x45,
-				xTractSize: 0x02,
-				zTractSize: 0x02,
+				tract: new TractInfo([0x40, 0x44], [0x42, 0x45]),
 			},
 		];
 

--- a/src/core/test/prop-test.ts
+++ b/src/core/test/prop-test.ts
@@ -6,8 +6,9 @@ import { resource } from '#test/files.js';
 
 describe('A prop subfile', function() {
 
+	this.timeout(0);
+
 	it('should be parsed & serialized correctly', function() {
-		this.timeout(0);
 		let dbpf = new DBPF(resource('city.sc4'));
 
 		let entry = dbpf.find({ type: FileType.Prop })!;
@@ -34,10 +35,8 @@ describe('A prop subfile', function() {
 	});
 
 	it('crashes on a poxed city', function() {
-
 		let dbpf = new Savegame(resource('poxed.sc4'));
 		expect(() => dbpf.props).to.throw(Error);
-
 	});
 
 });

--- a/src/core/tract-info.ts
+++ b/src/core/tract-info.ts
@@ -3,11 +3,11 @@ import type { tracts } from 'sc4/types';
 import type Box3 from './box-3.js';
 import type Stream from './stream.js';
 import type WriteBuffer from './write-buffer.js';
+import type { Vector3Like } from './vector-3.js';
 
 // # TractInfo
 // A class that contains some information about the tracts an object is part of. 
 // Tracts are squares of 4x4 tiles that are used within the item index. 
-type Vector3 = [x: number, y: number, z: number];
 type Vector2<T = tracts> = [x: T, z: T];
 export default class TractInfo {
 
@@ -62,8 +62,8 @@ export default class TractInfo {
 	// no bbox - such as flora - from a positional vector.
 	update(record: { bbox: Box3 }): this;
 	update(bbox: Box3): this;
-	update(position: Vector3): this;
-	update(from: { bbox: Box3 } | Box3 | Vector3): this {
+	update(position: Vector3Like): this;
+	update(from: { bbox: Box3 } | Box3 | Vector3Like): this {
 		if ('bbox' in from) {
 			return this.update(from.bbox);
 		}

--- a/src/core/tract-info.ts
+++ b/src/core/tract-info.ts
@@ -1,6 +1,6 @@
 // # tract-info.ts
 import type { tracts } from 'sc4/types';
-import type Box3 from './box3.js';
+import type Box3 from './box-3.js';
 import type Stream from './stream.js';
 import type WriteBuffer from './write-buffer.js';
 

--- a/src/core/tract-info.ts
+++ b/src/core/tract-info.ts
@@ -1,0 +1,84 @@
+// # tract-info.ts
+import type { tracts } from 'sc4/types';
+import type Box3 from './box3.js';
+import type Stream from './stream.js';
+import type WriteBuffer from './write-buffer.js';
+
+// # TractInfo
+// A class that contains some information about the tracts an object is part of. 
+// Tracts are squares of 4x4 tiles that are used within the item index. 
+type Vector3 = [x: number, y: number, z: number];
+type Vector2<T = tracts> = [x: T, z: T];
+export default class TractInfo {
+
+	// Tracts always start with an offset of 0x40 (64). Might be related to the 
+	// fact that the item index is actually a quadtree where objects are only 
+	// stored at the 4x4 level. Note sure if we'll abstract this away, we should 
+	// probably remain as close as possible to the raw data structures.
+	minX = 0x40;
+	minZ = 0x40;
+	maxX = 0x40;
+	maxZ = 0x40;
+
+	// Tracts are always 4x4 tiles, which means the *exponent* is given as 2
+	// (2² = 4). This is likely constant in all game objects, but for some 
+	// reason it is still stored in the savegame structures.
+	xTractSize = 0x0002;
+	zTractSize = 0x0002;
+
+	// ## constructor(min, max)
+	constructor(
+		min: Vector2<tracts> = [0x40, 0x40],
+		max: Vector2<tracts> = [0x40, 0x40],
+	) {
+		[this.minX, this.minZ] = min;
+		[this.maxX, this.maxZ] = max;
+	}
+
+	// ## parse(rs)
+	parse(rs: Stream) {
+		this.minX = rs.byte();
+		this.minZ = rs.byte();
+		this.maxX = rs.byte();
+		this.maxZ = rs.byte();
+		this.xTractSize = rs.word();
+		this.zTractSize = rs.word();
+		return this;
+	}
+
+	// ## write(ws)
+	write(ws: WriteBuffer) {
+		ws.byte(this.minX);
+		ws.byte(this.minZ);
+		ws.byte(this.maxX);
+		ws.byte(this.maxZ);
+		ws.word(this.xTractSize);
+		ws.word(this.zTractSize);
+		return this;
+	}
+
+	// ## update()
+	// Updates the tract info based on the given bbox, or in case an object has 
+	// no bbox - such as flora - from a positional vector.
+	update(bbox: Box3): this;
+	update(position: Vector3): this;
+	update(from: Box3 | Vector3): this {
+		const xSize = 16 * 2**this.xTractSize;
+		const zSize = 16 * 2**this.zTractSize;
+		if (isBbox(from)) {
+			this.minX = 0x40 + Math.floor(from.minX / xSize);
+			this.minZ = 0x40 + Math.floor(from.minZ / zSize);
+			this.maxX = 0x40 + Math.floor(from.minX / xSize);
+			this.maxZ = 0x40 + Math.floor(from.minX / zSize);
+		} else {
+			this.minX = this.maxX = 0x40 + Math.floor(from[0] / xSize);
+			this.minZ = this.maxZ = 0x40 + Math.floor(from[2] / zSize);
+		}
+		return this;
+	}
+
+}
+
+function isBbox(object: any): object is Box3 {
+	return Array.isArray(object[0]);
+}

--- a/src/core/tract-info.ts
+++ b/src/core/tract-info.ts
@@ -60,9 +60,13 @@ export default class TractInfo {
 	// ## update()
 	// Updates the tract info based on the given bbox, or in case an object has 
 	// no bbox - such as flora - from a positional vector.
+	update(record: { bbox: Box3 }): this;
 	update(bbox: Box3): this;
 	update(position: Vector3): this;
-	update(from: Box3 | Vector3): this {
+	update(from: { bbox: Box3 } | Box3 | Vector3): this {
+		if ('bbox' in from) {
+			return this.update(from.bbox);
+		}
 		const xSize = 16 * 2**this.xTractSize;
 		const zSize = 16 * 2**this.zTractSize;
 		if (isBbox(from)) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 // # types.ts
 import type { uint32 } from 'sc4/types';
-import type { FileType, SimGridFileType } from './file-types.js';
+import type { FileType, SavegameFileType, SimGridFileType } from './file-types.js';
 import FileClasses from './file-classes.js';
 import type Stream from './stream.js';
 import type { ValueOf } from 'type-fest';
@@ -28,7 +28,18 @@ export type SavegameObject = SavegameRecord & {
 	zMinTract: number;
 	xMaxTract: number;
 	zMaxTract: number;
+	xTractSize: number;
+	zTractSize: number;
+	minX: number;
+	minY: number;
+	minZ: number;
+	maxX: number;
+	maxY: number;
+	maxZ: number;
 };
+
+// All savegame file type ids.
+export type SavegameFileTypeId = ValueOf<typeof SavegameFileType>;
 
 // The FileTypeId is a literal type that contains all *known* type ids, as 
 // definied in the file-types.ts file. Note that it does not necessarily mean 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,7 @@ import FileClasses from './file-classes.js';
 import type Stream from './stream.js';
 import type { ValueOf } from 'type-fest';
 import type { kFileTypeArray } from './symbols.js';
+import type TractInfo from './tract-info.js';
 
 // Contains the type definition that a class implementing a DBPF file should 
 // minimally adhere to. The only requirement here is that it can be parsed from 
@@ -23,14 +24,7 @@ export type SavegameRecord = DBPFFile & { mem: uint32 };
 // their bounding box - given as xMinTract etc. We'll call these SavegameObjects. 
 // Typical examples are Buildings, Props, Flora, etc. Basically anything that 
 // can be added to the item index.
-export type SavegameObject = SavegameRecord & {
-	xMinTract: number;
-	zMinTract: number;
-	xMaxTract: number;
-	zMaxTract: number;
-	xTractSize: number;
-	zTractSize: number;
-};
+export type SavegameObject = SavegameRecord & { tract: TractInfo };
 
 // All savegame file type ids.
 export type SavegameFileTypeId = ValueOf<typeof SavegameFileType>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,7 @@ import FileClasses from './file-classes.js';
 import type Stream from './stream.js';
 import type { ValueOf } from 'type-fest';
 import type { kFileTypeArray } from './symbols.js';
+import type Bbox from './bbox.js';
 
 // Contains the type definition that a class implementing a DBPF file should 
 // minimally adhere to. The only requirement here is that it can be parsed from 
@@ -30,12 +31,7 @@ export type SavegameObject = SavegameRecord & {
 	zMaxTract: number;
 	xTractSize: number;
 	zTractSize: number;
-	minX: number;
-	minY: number;
-	minZ: number;
-	maxX: number;
-	maxY: number;
-	maxZ: number;
+	bbox: Bbox;
 };
 
 // All savegame file type ids.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,7 +5,6 @@ import FileClasses from './file-classes.js';
 import type Stream from './stream.js';
 import type { ValueOf } from 'type-fest';
 import type { kFileTypeArray } from './symbols.js';
-import type Bbox from './bbox.js';
 
 // Contains the type definition that a class implementing a DBPF file should 
 // minimally adhere to. The only requirement here is that it can be parsed from 
@@ -21,7 +20,7 @@ export type DBPFFile = {
 export type SavegameRecord = DBPFFile & { mem: uint32 };
 
 // Certain savegame records are also required to have some information about 
-// their bounding box - given as xMinTrac etc. We'll call these SavegameObjects. 
+// their bounding box - given as xMinTract etc. We'll call these SavegameObjects. 
 // Typical examples are Buildings, Props, Flora, etc. Basically anything that 
 // can be added to the item index.
 export type SavegameObject = SavegameRecord & {
@@ -31,7 +30,6 @@ export type SavegameObject = SavegameRecord & {
 	zMaxTract: number;
 	xTractSize: number;
 	zTractSize: number;
-	bbox: Bbox;
 };
 
 // All savegame file type ids.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,11 +1,17 @@
 // # types.ts
-import type { uint32 } from 'sc4/types';
-import type { FileType, SavegameFileType, SimGridFileType } from './file-types.js';
-import FileClasses from './file-classes.js';
+import type { uint32, ConstructorOptions as Options } from 'sc4/types';
+import type {
+	FileType,
+	SavegameFileType,
+	SimGridFileType,
+} from './file-types.js';
+import type FileClasses from './file-classes.js';
 import type Stream from './stream.js';
 import type { ValueOf } from 'type-fest';
 import type { kFileTypeArray } from './symbols.js';
 import type TractInfo from './tract-info.js';
+import type { Vector3, Vector3Like } from './vector-3.js';
+import type Box3 from './box-3.js';
 
 // Contains the type definition that a class implementing a DBPF file should 
 // minimally adhere to. The only requirement here is that it can be parsed from 

--- a/src/core/vector-3.ts
+++ b/src/core/vector-3.ts
@@ -8,7 +8,7 @@ export type Vector3Like = [x: number, y: number, z: number] | Vector3;
 // *value types*, so any operation on it returns a new vector. We don't modify 
 // the vector by reference! Compare this how the new JavaScript temporal api is 
 // designed.
-export default class Vector3 extends Array<number> {
+export class Vector3 extends Array<number> {
 	constructor(x: number = 0, y: number = 0, z: number = 0) {
 		super(x, y, z);
 	}
@@ -16,6 +16,9 @@ export default class Vector3 extends Array<number> {
 	get x() { return this[0]; }
 	get y() { return this[1]; }
 	get z() { return this[2]; }
+	set x(value: number) { this[0] = value; }
+	set y(value: number) { this[1] = value; }
+	set z(value: number) { this[2] = value; }
 
 	// ## add()
 	add(dv: Vector3Like) {
@@ -44,3 +47,4 @@ export default class Vector3 extends Array<number> {
 	}
 
 }
+export default Vector3;

--- a/src/core/vector-3.ts
+++ b/src/core/vector-3.ts
@@ -20,6 +20,11 @@ export class Vector3 extends Array<number> {
 	set y(value: number) { this[1] = value; }
 	set z(value: number) { this[2] = value; }
 
+	// ## clone()
+	clone() {
+		return new Vector3(...this);
+	}
+
 	// ## add()
 	add(dv: Vector3Like) {
 		let [dx, dy, dz] = dv;

--- a/src/core/vector-3.ts
+++ b/src/core/vector-3.ts
@@ -1,0 +1,46 @@
+// # vector-3.ts
+import type Stream from './stream.js';
+import type WriteBuffer from './write-buffer.js';
+export type Vector3Like = [x: number, y: number, z: number] | Vector3;
+
+// # Vector3
+// Represents a three-dimensional vector. Note that we consider vectors to be 
+// *value types*, so any operation on it returns a new vector. We don't modify 
+// the vector by reference! Compare this how the new JavaScript temporal api is 
+// designed.
+export default class Vector3 extends Array<number> {
+	constructor(x: number = 0, y: number = 0, z: number = 0) {
+		super(x, y, z);
+	}
+
+	get x() { return this[0]; }
+	get y() { return this[1]; }
+	get z() { return this[2]; }
+
+	// ## add()
+	add(dv: Vector3Like) {
+		let [dx, dy, dz] = dv;
+		return new Vector3(
+			this.x + dx,
+			this.y + dy,
+			this.z + dz,
+		);
+	}
+
+	// ## parse(rs)
+	parse(rs: Stream) {
+		this[0] = rs.float();
+		this[1] = rs.float();
+		this[2] = rs.float();
+		return this;
+	}
+
+	// ## write(ws)
+	write(ws: WriteBuffer) {
+		ws.float(this[0]);
+		ws.float(this[1]);
+		ws.float(this[2]);
+		return this;
+	}
+
+}

--- a/src/core/vertex.ts
+++ b/src/core/vertex.ts
@@ -2,6 +2,7 @@
 import Color from './color.js';
 import type WriteBuffer from './write-buffer.js';
 import type Stream from './stream.js';
+import type { meters } from 'sc4/types';
 
 // # Vertex
 // In quite a lot of subfiles often the sequence x, y, z, u, v, r, g, b, a 
@@ -10,12 +11,11 @@ import type Stream from './stream.js';
 // order to make it easier to work with this, we've put them inside a separate 
 // class.
 export default class Vertex {
-
-	x = 0;
-	y = 0;
-	z = 0;
-	u = 0;
-	v = 0;
+	x: meters = 0;
+	y: meters = 0;
+	z: meters = 0;
+	u: number = 0;
+	v: number = 0;
 	color = new Color();
 
 	// ## parse(rs)

--- a/src/core/write-buffer.ts
+++ b/src/core/write-buffer.ts
@@ -19,6 +19,7 @@ import type {
 	word,
     qword,
 } from 'sc4/types';
+import type Box3 from './box3.js';
 
 type HasWrite = { write: (arr: WriteBuffer) => any };
 type HasToBuffer = { toBuffer: () => Uint8Array };
@@ -127,6 +128,12 @@ export default class WriteBuffer extends SmartBuffer {
 	// Writes a vertex data structure to the buffer.
 	vertex(vertex: Vertex) {
 		vertex.write(this);
+	}
+
+	// ## bbox(bbox)
+	// Writes a bbox data structure to the buffer.
+	bbox(bbox: Box3) {
+		bbox.write(this);
 	}
 
 	// ## seal()

--- a/src/core/write-buffer.ts
+++ b/src/core/write-buffer.ts
@@ -21,6 +21,7 @@ import type {
 } from 'sc4/types';
 import type Box3 from './box3.js';
 import type TractInfo from './tract-info.js';
+import type { Vector3Like } from './vector-3.js';
 
 type HasWrite = { write: (arr: WriteBuffer) => any };
 type HasToBuffer = { toBuffer: () => Uint8Array };
@@ -114,6 +115,14 @@ export default class WriteBuffer extends SmartBuffer {
 		if (address > 0) {
 			this.dword(ptr.type);
 		}
+	}
+
+	// ## vector3()
+	// Writes away a 3D vector.
+	vector3(vector: Vector3Like) {
+		this.float(vector[0]);
+		this.float(vector[1]);
+		this.float(vector[2]);
 	}
 
 	// ## color(color)

--- a/src/core/write-buffer.ts
+++ b/src/core/write-buffer.ts
@@ -19,7 +19,7 @@ import type {
 	word,
     qword,
 } from 'sc4/types';
-import type Box3 from './box3.js';
+import type Box3 from './box-3.js';
 import type TractInfo from './tract-info.js';
 import type { Vector3Like } from './vector-3.js';
 

--- a/src/core/write-buffer.ts
+++ b/src/core/write-buffer.ts
@@ -20,6 +20,7 @@ import type {
     qword,
 } from 'sc4/types';
 import type Box3 from './box3.js';
+import type TractInfo from './tract-info.js';
 
 type HasWrite = { write: (arr: WriteBuffer) => any };
 type HasToBuffer = { toBuffer: () => Uint8Array };
@@ -128,6 +129,12 @@ export default class WriteBuffer extends SmartBuffer {
 	// Writes a vertex data structure to the buffer.
 	vertex(vertex: Vertex) {
 		vertex.write(this);
+	}
+
+	// ## tract(tractInfo)
+	// Writes a tract info data structure to the buffer.
+	tract(tract: TractInfo) {
+		tract.write(this);
 	}
 
 	// ## bbox(bbox)

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -30,6 +30,14 @@ export type TGIArray<
 	I extends uint32 = uint32
 > = [type: T, group: G, instance: I];
 
+// It's not always clear what units are being used, as you can have meters (1 
+// tile = 16 meters), tiles, or tracts - where 1 tract is dependent on the 
+// stored tract size, which is always 0x02 though. To make this more explicit, 
+// we'll alias the "number" type properly.
+export type meters = float;
+export type tiles = byte;
+export type tracts = byte;
+
 // A type that we often use to allow all non-function keys of a class to be 
 // specified as options.
 export type ConstructorOptions<T> = Omit<


### PR DESCRIPTION
This PR refactors a bunch of the occupant-type subfiles (prop, building, flora, ...) to include new data structures:

- The `min[XYZ]` and `max[XYZ]` fields of those data structures are now replaced by a bounding box data structure called `Box3`. This should make it easier to perform geometric operations - such as translations - on those objects.
- The tract-related fields - such as `xMinTract` and `xTractSize` - are replaced by a data structure called `TractInfo`. It is similar in function as the bounding box data structure, and allows updating the tract information based on a bbox or position.