### PR TITLE
refactor: turn off multithreading for small plugin folders

### DIFF
--- a/src/plugins/test/plugin-index-test.ts
+++ b/src/plugins/test/plugin-index-test.ts
@@ -6,9 +6,6 @@ import { resource } from '#test/files.js';
 
 describe('The plugin index', function() {
 
-	this.slow(2000);
-	this.timeout(10_000);
-
 	it('indexes all files in a directory', async function() {
 
 		let index = new Index({

--- a/src/threading/worker-thread.ts
+++ b/src/threading/worker-thread.ts
@@ -1,5 +1,5 @@
 // # worker-thread.js
-import { parentPort } from 'node:worker_threads';
+import { isMainThread, parentPort } from 'node:worker_threads';
 import type { StructuredCloneable } from 'type-fest';
 type MaybePromise<T> = Promise<T> | T;
 type TaskInfo = {
@@ -8,10 +8,17 @@ type TaskInfo = {
 };
 
 // Helper function for running code inside a worker thread that takes care of 
-// the task ids automatically.
+// the task ids automatically. It also ensures that we can run both in the main 
+// thread, as in the worker thread.
 export default function workerThread(fn: (...args: any[]) => MaybePromise<StructuredCloneable>) {
-	parentPort!.on('message', async ({ id, task }: TaskInfo) => {
-		let result = await fn(task);
-		parentPort!.postMessage({ id, type: 'result', result });
-	});
+	if (isMainThread) {
+		return function(task: StructuredCloneable) {
+			return fn(task);
+		};
+	} else {
+		parentPort!.on('message', async ({ id, task }: TaskInfo) => {
+			let result = await fn(task);
+			parentPort!.postMessage({ id, type: 'result', result });
+		});
+	}
 }


### PR DESCRIPTION
In small plugin folders, multithreading can actually slow us down, so it is now turned off automatically in case there are less than 1,000 files.