### PR TITLE
refactor!: move commands to dedicated groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:
 
 which can be used for example as
 ```
-sc4 growify -r Low -c High --no-historical "City - Plopped city.sc4"
+sc4 city growify -r Low -c High --no-historical "City - Plopped city.sc4"
 ```
 
 ## Backups

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ As such you can simply double-click one of your cities, and subsequently it will
 ### Advanced usage
 
 If you are an advanced user and you have some experience with cli tools, then there is also the option to use `sc4` by running one of its commands directly.
-Run `sc4 --help` in a command prompt to get an overview of all available commands:
+Run `sc4 --help` in a command prompt to get an overview of all available commands.
+Beware that certain actions that a typical end-user would not regularly use are not available in interactive mode!
+
+Note that since v0.2.0, the commands have been grouped with subcommands.
+For example, the old `sc4 growify <city>` command can now be used as `sc4 city growify <city>`, and `sc4 plop-all <city>` is now `sc4 city plop`.
 
 ```
 Usage: sc4 [options] [command]
@@ -52,30 +56,21 @@ You can use the individual commands listed below, or just run sc4 without any co
 Run sc4 [command] --help to view all options for the individual commands.
 
 Options:
-  -V, --version                              output the version number
-  -h, --help                                 display help for command
+  -V, --version  output the version number
+  -h, --help     display help for command
 
 Commands:
-  historical [options] <city>                Make buildings within the given city historical
-  growify [options] <city>                   Convert plopped buildings into functional growables
-  create-submenu-patch [options] [files...]  Adds all specified lots to the given menu using the Exemplar Patching method
-  create-new-submenu [options] <icon>        Generates a new submenu button
-  pipes <city>                               Create the optimal pipe layout in the given city
-  plop-all [options] <city> [patterns...]    Plops all lots that match the patterns in the city. DO NOT use this on established cities!
-  track [options] [patterns...]              Finds all dependencies for the files that match the given patterns
-  tileset [options] [dir]                    Set the tilesets for all buildings in the given directory
-  backup [options]                           Backup a region or your entire plugins folder
-  dump <city>                                Give a human-readable representation of all lots in the city
-  refs [options] <city>                      Finds internal memory references within a city
-  pointer <city> <pointer>                   Finds the subfile entery addressed by the given pointer
-  tracts [options] <city>                    Changes the active tilesets in the given city
-  config                                     Allows modifying the config file. Be careful with this if you don't know what you're doing!
+  city           Modify savegames. Run sc4 city to view all available commands
+  submenu        Manage submenus. Run sc4 submenu to list available commands
+  plugins        Manage plugins. Run sc4 plugins to list available commands
+  misc           Contains various commands that are experimental and not officially supported. Be very careful when using them!
+  config         Manage sc4 configuration. Run sc4 config to list available commands
 ```
 
 You can run `sc4 [command] --help` to get an overview of the options for every command.
-For example, if you run `sc4 growify --help` you'll see
+For example, if you run `sc4 city growify --help` you'll see
 ```
-Usage: sc4 growify [options] <city>
+Usage: sc4 city growify [options] <city>
 
 Convert plopped buildings into functional growables
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -205,38 +205,6 @@ export async function refs(opts) {
 
 }
 
-// # pointer(opts)
-export async function pointer(opts) {
-	let {
-		logger = defaultLogger,
-		dbpf,
-		pointer,
-	} = opts;
-
-	logger.info('Searching for', hex(opts.pointer));
-	let ctx = dbpf.createContext();
-	let refs = ctx.findAllMemRefs();
-	let entry = refs.find(ref => {
-		return ref.mem === pointer;
-	});
-	if (!entry) {
-		logger.error('Pointer not found!');
-		return;
-	}
-
-	// Check if it matches a specific file type.
-	let name = '';
-	for (let [key, value] of Object.entries(FileType)) {
-		if (value === entry.type) {
-			name = ` (${key})`;
-			break;
-		}
-	}
-
-	logger.ok(`Found in ${hex(entry.type)}${name}`);
-
-}
-
 // # duplicates(opts)
 // Finds duplicates files in a plugin folder.
 export function duplicates(opts) {

--- a/src/cli/commands/city-pointer-command.ts
+++ b/src/cli/commands/city-pointer-command.ts
@@ -1,0 +1,25 @@
+// # city-pointer-command.ts
+import path from 'node:path';
+import { Savegame } from 'sc4/core';
+import { inspect } from 'sc4/utils';
+import logger from '#cli/logger.js';
+
+export function cityPointer(city: string, pointer: number | string) {
+	let file = path.resolve(process.cwd(), city);
+	let dbpf = new Savegame(file);
+	let address = +pointer;
+	logger.info('Searching for', inspect.hex(address));
+	let ctx = dbpf.createContext();
+	let records = ctx.getFlatRecordList();
+	let record = records.find(record => record.pointer.address === address);
+	if (!record) {
+		logger.error('Pointer not found!');
+		return 1;
+	}
+	console.log({
+		class: record.label,
+		pointer: record.pointer,
+		offset: record.offset,
+		buffer: record.buffer,
+	});
+}

--- a/src/cli/commands/city-refs-command.ts
+++ b/src/cli/commands/city-refs-command.ts
@@ -1,0 +1,44 @@
+// # city-refs-command.ts
+import logger from '#cli/logger.js';
+import path from 'node:path';
+import { Savegame } from 'sc4/core';
+import { findPatternOffsets } from 'src/core/helpers.js';
+
+type CityRefsCommandOptions = {
+	address?: number | string;
+	type?: number | string;
+};
+
+export function cityRefs(city: string, opts: CityRefsCommandOptions) {
+	let file = path.resolve(process.cwd(), city);
+	let dbpf = new Savegame(file);
+
+	// Transform the adddress or type we have to look for into a Uint8Array that 
+	// we'll subsequently look for in the raw buffers.
+	let integer = +opts.address! || +opts.type!;
+	if (!integer) {
+		logger.error('Please specify a non-zero address or type!');
+		return;
+	}
+	let pattern = new Uint8Array(4);
+	let view = new DataView(pattern.buffer);
+	view.setUint32(0, integer, true);
+
+	// Loop all records and the find for the patterns in that buffer.
+	let ctx = dbpf.createContext();
+	let refs = ctx.getRecordList();
+	let list = [];
+	for (let row of refs) {
+		let { entry } = row;
+		let buffer = entry.decompress();
+		let offsets = findPatternOffsets(buffer, pattern);
+		if (offsets.length > 0) {
+			list.push({
+				class: row.label,
+				count: offsets.length,
+			});
+		}
+	}
+	console.table(list);
+
+}

--- a/src/cli/commands/city-refs-command.ts
+++ b/src/cli/commands/city-refs-command.ts
@@ -2,7 +2,7 @@
 import logger from '#cli/logger.js';
 import path from 'node:path';
 import { Savegame } from 'sc4/core';
-import { findPatternOffsets } from 'src/core/helpers.js';
+import { findPatternOffsets } from 'sc4/utils';
 
 type CityRefsCommandOptions = {
 	address?: number | string;

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -9,3 +9,4 @@ export * from './config-command.js';
 export * from './plop-all-command.js';
 export * from './track-command.js';
 export * from './city-pointer-command.js';
+export * from './city-refs-command.js';

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -8,3 +8,4 @@ export * from './scan-for-menus-command.js';
 export * from './config-command.js';
 export * from './plop-all-command.js';
 export * from './track-command.js';
+export * from './city-pointer-command.js';

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -486,17 +486,8 @@ export function factory(program) {
 
 	city
 		.command('pointer <city> <pointer>')
-		.storeOptionsAsProperties()
 		.description('Finds the subfile entry addressed by the given pointer')
-		.action(function(city, pointer) {
-			let dir = this.cwd;
-			let file = path.resolve(dir, city);
-			let buff = fs.readFileSync(file);
-			let opts = baseOptions();
-			opts.dbpf = new DBPF(buff);
-			opts.pointer = +pointer;
-			api.pointer(opts);
-		});
+		.action(commands.cityPointer);
 
 	// Command for switching the active tilesets in a city.
 	misc

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -5,9 +5,8 @@ import cppClasses from './cpp-classes.js';
 import crc32 from './crc.js';
 import { kFileType, kFileTypeArray } from './symbols.js';
 import { FileType } from './enums.js';
+import { findPatternOffsets } from 'sc4/utils';
 import type Entry from './dbpf-entry.js';
-import { indexOf } from 'uint8array-extras';
-import { buffer } from 'node:stream/consumers';
 
 // # getClassType(object)
 // Inspects the object and returns its Type ID. If a class constructor is 
@@ -107,20 +106,4 @@ export function removePointers(record: Uint8Array): Uint8Array {
 		}
 	}
 	return record;
-}
-
-// # findPatternOffsets(buffer, pattern)
-// Finds all offsets of the given Uint8Array pattern.
-export function findPatternOffsets(buffer: Uint8Array, pattern: Uint8Array) {
-	let index = 0;
-	let pivot = buffer;
-	let offsets: number[] = [];
-	while (index > -1) {
-		index = indexOf(pivot, pattern);
-		if (index > -1) {
-			offsets.push(index);
-			pivot = pivot.subarray(index + pattern.length);
-		}
-	}
-	return offsets;
 }

--- a/src/core/savegame-context.ts
+++ b/src/core/savegame-context.ts
@@ -17,7 +17,10 @@ type RecordRow = {
 };
 type RecordInfo = {
 	pointer: Pointer;
+	type: number;
+	address: number;
 	offset: number;
+	label: string;
 	buffer: Uint8Array;
 };
 
@@ -133,6 +136,9 @@ export default class SavegameContext {
 				let address = SmartBuffer.fromBuffer(buffer).readUInt32LE(8);
 				row.records.push({
 					pointer: new Pointer(entry.type, address),
+					type: entry.type,
+					label: row.label,
+					address,
 					offset,
 					buffer,
 				});

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -3,6 +3,7 @@ import { util } from './node-builtins.js';
 import type { Constructor, UnknownRecord } from 'type-fest';
 import type { uint32, TGILiteral } from 'sc4/types';
 import type { InspectOptionsStylized } from 'node:util';
+import { indexOf } from 'uint8array-extras';
 
 // Julian day offset between unix epoch and Julian Date 0.
 const JULIAN_OFFSET = 2440587.5;
@@ -223,4 +224,20 @@ export function isLittleEndian() {
 // # isBigEndian()
 export function isBigEndian() {
 	return !isLittleEndian();
+}
+
+// # findPatternOffsets(buffer, pattern)
+// Finds all offsets of the given Uint8Array pattern.
+export function findPatternOffsets(buffer: Uint8Array, pattern: Uint8Array) {
+	let index = 0;
+	let pivot = buffer;
+	let offsets: number[] = [];
+	while (index > -1) {
+		index = indexOf(pivot, pattern);
+		if (index > -1) {
+			offsets.push(index);
+			pivot = pivot.subarray(index + pattern.length);
+		}
+	}
+	return offsets;
 }


### PR DESCRIPTION
This PR changes the way the cli has to be used in non-interactive mode. Commands are now grouped in various groups. For example, commands that operate on savegames are now found in `sc4 city`, .e.g. `sc4 city growify <city>`.

The submenu commands can now be found in `sc4 submenu`, e.g. `sc4 submenu create` and `sc4 submenu add`. Use `sc4 --help` to display the list of all subcommands.