### PR TITLE
feat: support using default description for submenus

### DIFF
--- a/src/cli/flows/new-submenu-flow.js
+++ b/src/cli/flows/new-submenu-flow.js
@@ -8,10 +8,16 @@ export async function newSubmenu() {
 		message: 'What is the name of the submenu?',
 		required: true,
 	});
+
+	// If the description is left empty, we have to set it to "undefined" so 
+	// that the default description is used.
 	let description = await prompts.input({
-		message: 'Enter the description of the submenu:',
+		message: 'Enter the description of the submenu (leave open to use the default)',
 		default: '',
 	});
+	if (description.trim().length === 0) {
+		description = undefined;
+	}
 	let parent = await prompts.menu({
 		message: 'Select the parent menu',
 	});

--- a/src/plugins/create-submenu-button.ts
+++ b/src/plugins/create-submenu-button.ts
@@ -39,9 +39,11 @@ export default async function createSubmenuButton(
 	opts: createSubmenuButtonOptions,
 ) {
 
+	// If no description is specified, we use the default description of memo's 
+	// submenus, being "Click here to open submenu".
 	let {
 		name,
-		description = '',
+		description = [0x2026960b, 0x123006aa, 0x6e967dff],
 		buttonId = randomId({ except: excluded }),
 		icon,
 		parent,

--- a/src/plugins/test/create-submenu-button-test.ts
+++ b/src/plugins/test/create-submenu-button-test.ts
@@ -83,4 +83,18 @@ describe('#createSubmenuButton()', function() {
 
 	});
 
+	it('uses the default description if none specified', async function() {
+
+		let { dbpf } = await createSubmenuButton({
+			name: 'Submenu',
+			parent: 0xabcde123,
+		});
+
+		let clone = new DBPF(dbpf.toBuffer());
+		let exemplar = clone.find({ type: FileType.Exemplar })!.read();
+		let key = exemplar.get('ItemDescriptionKey');
+		expect(key).to.eql([0x2026960b, 0x123006aa, 0x6e967dff]);
+
+	});
+
 });

--- a/src/plugins/unpack-submenu.ts
+++ b/src/plugins/unpack-submenu.ts
@@ -146,6 +146,13 @@ class Unpacker {
 			let parent = this.menus.get(menuId);
 			if (!parent) continue;
 
+			// Log that we're reading the cohort.
+			let file = entry.dbpf.file!;
+			if (!had.has(file)) {
+				had.add(file);
+				logger?.info(`Reading ${path.relative(directory, file)}`);
+			}
+
 			// Read in the target file if it already exists so that we can 
 			// ensure we don't add pairs twice.
 			let { dbpf } = entry;


### PR DESCRIPTION
It's now possible to use the default description for submenus (TGI 0x2026960b, 0x123006aa, 0x6e967dff]) by leaving the description open. This won't create a new LTEXT entry for the description, but refer to memo's original one.