### PR TITLE
feat: add `sc4 dbpf extract` command

### DIFF
--- a/src/cli/commands/dbpf-extract-command.ts
+++ b/src/cli/commands/dbpf-extract-command.ts
@@ -1,0 +1,87 @@
+// # dbpf-extract-command.ts
+import path from 'node:path';
+import fs from 'node:fs';
+import ora from 'ora';
+import PQueue from 'p-queue';
+import { DBPF, FileType, type Entry } from 'sc4/core';
+import type { TGILiteral } from 'sc4/types';
+
+type DbpfExtractCommandOptions = {} & Partial<TGILiteral>;
+
+export async function dbpfExtract(file: string, options: DbpfExtractCommandOptions) {
+
+	// DBPF files can be pretty large, so we won't load them all in memory, but 
+	// make use of the random file system access.
+	let fullPath = path.resolve(process.cwd(), file);
+	let dbpf = new DBPF({
+		file: fullPath,
+		parse: false,
+	});
+	let filter = createFilter(options);
+
+	// Ensure that the output folder exists.
+	let output = path.resolve(
+		process.cwd(),
+		path.basename(file, path.extname(file))
+	);
+	await fs.promises.mkdir(output, { recursive: true });
+
+	// Run as much as possible in parallel, which means we won't use a simple 
+	// loop, but create promises instead, but we have to make sure to not create
+	// too many open file handles either, so use a promise queue.
+	let queue = new PQueue({ concurrency: 250 });
+	let spinner = ora(`Reading ${dbpf.file}`).start();
+	await dbpf.parseAsync();
+	let counter = 0;
+	for (let entry of dbpf) {
+		if (!filter(entry)) continue;
+		counter++;
+		let { id } = entry;
+		queue.add(async () => {
+			spinner.text = `Reading ${id}`;
+			let buffer = await entry.decompressAsync();
+
+			// If it's an LTEXT, we just export it as a .txt file, that's 
+			// easier.
+			let basename = `${id}${getExtension(entry)}`;
+			if (entry.type === FileType.LTEXT) {
+				buffer = Buffer.from(String(entry.read()), 'utf8');
+			}
+			await fs.promises.writeFile(path.join(output, basename), buffer);
+
+		});
+	}
+	await queue.onIdle();
+	spinner.succeed(`Extracted ${counter} files from ${dbpf.file}`);
+
+}
+
+function createFilter(query: Partial<TGILiteral>) {
+	return function(entry: Entry) {
+		for (let key of ['type', 'group', 'instance'] as const) {
+			if (query[key] !== undefined && entry[key] !== query[key]) {
+				return false;
+			}
+		}
+		return true;
+	}
+}
+
+// # getExtension(entry)
+// Figures out the extension of the entry. We only use an extension for a bunch 
+// of known file types, such as png etc.
+function getExtension(entry: Entry): string {
+	switch (entry.type) {
+		case FileType.PNG: return '.png';
+		case FileType.LTEXT: return '.txt';
+		case FileType.Exemplar: return '.exemplar';
+		case FileType.Cohort: return '.cohort';
+		case FileType.DIR: return '.dir';
+		case FileType.FSH: return '.fsh';
+		case FileType.S3D: return '.s3d';
+		case FileType.LUA: return '.lua';
+		case FileType.XML: return '.xml';
+		case FileType.SC4Path: return '.sc4path';
+		default: return '';
+	}
+}

--- a/src/cli/commands/dbpf-extract-command.ts
+++ b/src/cli/commands/dbpf-extract-command.ts
@@ -73,6 +73,7 @@ function createFilter(query: Partial<TGILiteral>) {
 function getExtension(entry: Entry): string {
 	switch (entry.type) {
 		case FileType.PNG: return '.png';
+		case FileType.Thumbnail: return '.png';
 		case FileType.LTEXT: return '.txt';
 		case FileType.Exemplar: return '.exemplar';
 		case FileType.Cohort: return '.cohort';

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -11,3 +11,4 @@ export * from './track-command.js';
 export * from './city-pointer-command.js';
 export * from './city-refs-command.js';
 export * from './submenu-unpack-command.js';
+export * from './dbpf-extract-command.js';

--- a/src/cli/parsers.ts
+++ b/src/cli/parsers.ts
@@ -1,0 +1,27 @@
+// # parsers.ts
+import { InvalidArgumentError } from 'commander';
+import { FileType } from 'sc4/core';
+
+export function number(value: string) {
+	let parsedValue = +value;
+	if (!Number.isFinite(parsedValue)) {
+		throw new InvalidArgumentError('Not a number');
+	}
+	return parsedValue;
+}
+
+let lc = Object.fromEntries(
+	Object
+		.entries(FileType)
+		.map(([type, value]) => [type.toLowerCase(), value]),
+);
+export function typeId(value: string) {
+	if (value in lc) {
+		return lc[value];
+	}
+	try {
+		return number(value);
+	} catch (e) {
+		throw new InvalidArgumentError('Not a number or known file type');
+	}
+}

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -171,6 +171,8 @@ export function factory(program) {
 		.option('-t, --type <type>', 'Only extract files with the given TypeID', parsers.typeId)
 		.option('-g, --group <group>', 'Only extract files with the given GroupID', parsers.number)
 		.option('-i, --instance <instance>', 'Only extract files with the given InstanceID', parsers.number)
+		.option('-f, --force', 'Force overwriting existing output files')
+		.option('-o, --output <directory>', 'Output directory. Defaults to the current working directory')
 		.option('--yaml', 'Extract exemplars & cohorts as yaml')
 		.action(commands.dbpfExtract);
 

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -166,14 +166,16 @@ export function factory(program) {
 		.description(`Operate on DBPF files. Run ${chalk.magentaBright('sc4 dbpf')} to list available commands`);
 
 	dbpf
-		.command('extract <dbpf>')
-		.description('Extracts the contents of a DBPF file')
-		.option('-t, --type <type>', 'Only extract files with the given TypeID', parsers.typeId)
-		.option('-g, --group <group>', 'Only extract files with the given GroupID', parsers.number)
-		.option('-i, --instance <instance>', 'Only extract files with the given InstanceID', parsers.number)
+		.command('extract')
+		.description('Extracts the contents of one or more DBPF files')
+		.argument('<dbpf...>', 'Glob pattern(s) of DBPF files to match, e.g. **/*.{sc4lot,dat}')
+		.option('-t, --type <type>', 'Only extract files with the given TypeID (e.g. png, 0x6534284A)', parsers.typeId)
+		.option('-g, --group <group>', 'Only extract files with the given GroupID (e.g. 0x123006aa)', parsers.number)
+		.option('-i, --instance <instance>', 'Only extract files with the given InstanceID (e.g. 0x00003000)', parsers.number)
 		.option('-f, --force', 'Force overwriting existing output files')
 		.option('-o, --output <directory>', 'Output directory. Defaults to the current working directory')
 		.option('--yaml', 'Extract exemplars & cohorts as yaml')
+		.option('--no-tgi', 'Skips creating .TGI files')
 		.action(commands.dbpfExtract);
 
 	// There are several commands that we have implemented, but they need to be 

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -171,6 +171,7 @@ export function factory(program) {
 		.option('-t, --type <type>', 'Only extract files with the given TypeID', parsers.typeId)
 		.option('-g, --group <group>', 'Only extract files with the given GroupID', parsers.number)
 		.option('-i, --instance <instance>', 'Only extract files with the given InstanceID', parsers.number)
+		.option('--yaml', 'Extract exemplars & cohorts as yaml')
 		.action(commands.dbpfExtract);
 
 	// There are several commands that we have implemented, but they need to be 

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -9,6 +9,7 @@ import * as commands from '#cli/commands';
 import { DBPF, FileType } from 'sc4/core';
 import * as api from 'sc4/api';
 import { hex } from 'sc4/utils';
+import * as parsers from './parsers.js';
 import version from './version.js';
 
 const Style = {
@@ -158,6 +159,19 @@ export function factory(program) {
 		.option('-d, --directory <dir>', 'The directory to match the patterns against. Defaults to your configured plugins folder')
 		.option('--tree', 'Shows the entire dependency tree')
 		.action(commands.track);
+
+	// Commands that operate specifically on dbpfs, such as extracting a DBPF.
+	const dbpf = program
+		.command('dbpf')
+		.description(`Operate on DBPF files. Run ${chalk.magentaBright('sc4 dbpf')} to list available commands`);
+
+	dbpf
+		.command('extract <dbpf>')
+		.description('Extracts the contents of a DBPF file')
+		.option('-t, --type <type>', 'Only extract files with the given TypeID', parsers.typeId)
+		.option('-g, --group <group>', 'Only extract files with the given GroupID', parsers.number)
+		.option('-i, --instance <instance>', 'Only extract files with the given InstanceID', parsers.number)
+		.action(commands.dbpfExtract);
 
 	// There are several commands that we have implemented, but they need to be 
 	// reworked. We'll put thos under the "misc" category and instruct users not 

--- a/src/core/exemplar.ts
+++ b/src/core/exemplar.ts
@@ -70,6 +70,10 @@ const idToName: Map<number, string> = new Map(
 		return [+(object as NumberLike), name as string];
 	}),
 );
+let config = +ExemplarProperty.LotConfigPropertyLotObject;
+for (let i = 1; i < 1280; i++) {
+	idToName.set(config+i, 'LotConfigPropertyLotObject');
+}
 
 // We no longer use an enum for indicating the type of an exemplar property. 
 // Instead we use the native built-in JavaScript typed arrays to indicate the 
@@ -385,9 +389,10 @@ abstract class BaseExemplar {
 		return {
 			parent: [...this.parent],
 			properties: this.props.map(prop => {
+				let { name } = prop;
 				return {
 					id: prop.id,
-					name: prop.name,
+					...(name ? { name } : null),
 					type: getJsonType(prop.type),
 					value: prop.value,
 				};

--- a/src/core/file-types.ts
+++ b/src/core/file-types.ts
@@ -55,6 +55,7 @@ export const SavegameFileType = {
 	Pipe: 0x49c05b9f,
 	PlumbingSimulator: 0x0990c075,
 	ZoneManager: 0x298f9b2d,
+	Thumbnail: 0x8a2482b9,
 
 	// Terrain map is a bit special because it is also identified by group and 
 	// instance inside a Savegame, but obviously the type id is still needed 

--- a/src/core/test/exemplar-test.ts
+++ b/src/core/test/exemplar-test.ts
@@ -135,6 +135,22 @@ describe('The Exemplar file', function() {
 
 	});
 
+	it('converts numbers to bigints if that\'s the type', function() {
+
+		let exemplar = new Exemplar({
+			props: [
+				{
+					id: +ExemplarProperty.BulldozeCost,
+					type: BigInt64Array,
+					value: 10,
+				},
+			],
+		});
+		let [prop] = exemplar;
+		expect(prop.value).to.equal(10n);
+
+	});
+
 	describe('#get()', function() {
 
 		it('automatically unwraps single-value arrays for non-array properties', function() {
@@ -203,7 +219,23 @@ describe('The Exemplar file', function() {
 				props: [
 					{
 						id: +ExemplarProperty.ExemplarType,
+						type: Uint32Array,
 						value: 0x21,
+					},
+					{
+						id: +ExemplarProperty.BulldozeCost,
+						type: BigInt64Array,
+						value: 46723n,
+					},
+					{
+						id: +ExemplarProperty.ItemDescription,
+						type: String,
+						value: 'This is a description',
+					},
+					{
+						id: +ExemplarProperty.OccupantSize,
+						type: Float32Array,
+						value: [10.5, 3.5, 2.75],
 					},
 				],
 			});
@@ -216,6 +248,24 @@ describe('The Exemplar file', function() {
 						type: 'Uint32',
 						name: 'ExemplarType',
 						value: 0x21,
+					},
+					{
+						id: +ExemplarProperty.BulldozeCost,
+						type: 'Sint64',
+						name: 'BulldozeCost',
+						value: 46723n,
+					},
+					{
+						id: +ExemplarProperty.ItemDescription,
+						type: 'String',
+						name: 'ItemDescription',
+						value: 'This is a description',
+					},
+					{
+						id: +ExemplarProperty.OccupantSize,
+						type: 'Float32',
+						name: 'OccupantSize',
+						value: [10.5, 3.5, 2.75],
 					},
 				],
 			});

--- a/src/core/test/exemplar-test.ts
+++ b/src/core/test/exemplar-test.ts
@@ -27,14 +27,16 @@ describe('The Exemplar file', function() {
 
 	});
 
-	it('should read textual exemplars', function() {
+	it('reads textual exemplars', function() {
 
 		let file = resource('quotes.sc4desc');
 		let buff = fs.readFileSync(file);
 		let dbpf = new DBPF(buff);
 
 		let entry = dbpf.exemplars[0];
-		entry.read();
+		let exemplar = entry.read();
+		let pollution = exemplar.get('PollutionAtCenter');
+		expect(pollution).to.eql([1, 1, 4, 0]);
 
 	});
 
@@ -187,6 +189,36 @@ describe('The Exemplar file', function() {
 					expect(cloned).to.eql(prop);
 				}
 			}
+
+		});
+
+	});
+
+	describe('#toJSON()', function() {
+
+		it('serializes to JSON', function() {
+
+			let exemplar = new Exemplar({
+				parent: [FileType.Cohort, 0x01234567, 0xfedcba98],
+				props: [
+					{
+						id: +ExemplarProperty.ExemplarType,
+						value: 0x21,
+					},
+				],
+			});
+			let json = exemplar.toJSON();
+			expect(json).to.eql({
+				parent: [FileType.Cohort, 0x01234567, 0xfedcba98],
+				properties: [
+					{
+						id: +ExemplarProperty.ExemplarType,
+						type: 'Uint32',
+						name: 'ExemplarType',
+						value: 0x21,
+					},
+				],
+			});
 
 		});
 

--- a/src/core/test/ltext-test.ts
+++ b/src/core/test/ltext-test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { compareUint8Arrays } from 'uint8array-extras';
 import DBPF from '../dbpf.js';
 import { resource } from '#test/files.js';
+import FileType from '../file-types.js';
 
 describe('The LTEXT file type', function() {
 
@@ -12,8 +13,23 @@ describe('The LTEXT file type', function() {
 		let entry = dbpf.find(0x2026960b, 0x123007bb, 0x83e040bb)!;
 		let ltext = entry.read();
 		expect(ltext.value).to.equal('Signage');
+		expect(ltext.encoding).to.equal(0x1000);
 		let buffer = ltext.toBuffer();
 		expect(compareUint8Arrays(buffer, entry.buffer!)).to.equal(0);
+
+	});
+
+	it('handles 8-bit LTEXTs', function() {
+
+		let dbpf = new DBPF(resource('City - Large developed.sc4'));
+		let entries = dbpf.findAll({ type: FileType.LTEXT });
+		for (let entry of entries) {
+			let buffer = entry.decompress();
+			let ltext = entry.read();
+			expect(ltext.encoding).to.equal(0x0000);
+			expect(ltext.value).to.equal('Temp.png');
+			expect(compareUint8Arrays(buffer, ltext.toBuffer())).to.equal(0);
+		}
 
 	});
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -241,3 +241,12 @@ export function findPatternOffsets(buffer: Uint8Array, pattern: Uint8Array) {
 	}
 	return offsets;
 }
+
+// Helper function that mimicks the "safe assignment operator", asynchronously.
+export async function attempt(fn: () => any) {
+	try {
+		return [null, await fn()];
+	} catch (e) {
+		return [e, null];
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
 			"#cli/*": ["src/cli/*"],
 		},
 		"lib": ["es2024"],
-		"target": "es2024",
+		"target": "esnext",
 		"module": "nodenext",
 		"moduleResolution": "nodenext",
 		"verbatimModuleSyntax": true,


### PR DESCRIPTION
This PR adds a new command that can be used to extract dbpf files.

Run `sc4 dbpf extract --help` to display help:
```
Usage: sc4 dbpf extract [options] <dbpf...>

Extracts the contents of one or more DBPF files

Arguments:
  dbpf                       Glob pattern(s) of DBPF files to match, e.g. **/*.{sc4lot,dat}

Options:
  -t, --type <type>          Only extract files with the given TypeID (e.g. png, 0x6534284A)
  -g, --group <group>        Only extract files with the given GroupID (e.g. 0x123006aa)
  -i, --instance <instance>  Only extract files with the given InstanceID (e.g. 0x00003000)
  -f, --force                Force overwriting existing output files
  -o, --output <directory>   Output directory. Defaults to the current working directory
  --yaml                     Extract exemplars & cohorts as yaml
  --no-tgi                   Skips creating .TGI files
  -h, --help                 display help for command
```

Examples:
```sh
# Extract all .sc4lot files in this folder and all its children to the ./dist folder
sc4 dbpf extract **/*.sc4lot -o dist

# Extract all png files from lot.sc4desc to the current working directory, and
# overwrite existing files
sc4 dbpf extract lot.sc4desc --type png -f

# Extract all exemplars from plugin.dat to the ./dist folder, using yaml syntax
sc4 dbpf extract plugin.dat -t 0x6534284A -o dist --yaml

# Extract the main city thumbnail from a savegame, and don't generate a .TGI
# file
sc4 dbpf extract "City - My City.sc4" --type thumbnail -i 0x00000000 --no-tgi
```