### PR TITLE
fix: support non-interactive terminals

### DIFF
--- a/src/cli/setup-env.js
+++ b/src/cli/setup-env.js
@@ -58,6 +58,10 @@ async function ensureInstallation() {
 		return folder;
 	}
 
+	// If this is not an interactive terminal, we can't prompt the user of 
+	// course.
+	if (!process.stdin.isTTY) return process.cwd();
+
 	// If we didn't find a SimCity 4 installation folder, then we'll notify the 
 	// user that they might need to locate it themselves, but first we'll ask if 
 	// they even have SimCity 4 installed.
@@ -141,6 +145,9 @@ async function ensureFolder(name, paths) {
 		return folder;
 	}
 	spinner.fail(`SimCity 4 ${name} folder not found`);
+
+	// If this is not an interactive terminal, we can't continue.
+	if (!process.stdin.isTTY) return process.cwd();
 
 	// If we didn't find the folder we're looking for, ask the user whether they 
 	// want to select one themselves.


### PR DESCRIPTION
Currently the cli runs a setup script that tries to locate the user's installation, plugins and regions folder. If it can't find them automatically, it will prompt the user to locate them. However, that won't work in a non-interactive terminal - like on GitHub actions - so in this case we'll now exit early and won't prompt the user.

Note: if using this on GH actions, you can still specify the environment variables `SC4_INSTALLATION`, `SC4_PLUGINS` and `SC4_REGIONS`.