### PR TITLE
feat: add `--props` option to `sc4 city plop` command

### DIFF
--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -700,7 +700,7 @@ export default class CityManager {
 
 		// Create the prop & position correctly.
 		let { terrain } = this.dbpf;
-		let yPos = terrain!.query(position.x, *position.z);
+		let yPos = terrain!.query(position.x, position.z);
 		let y = position.y + yPos;
 		let prop = new Prop({
 			mem: this.mem(),

--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -693,9 +693,14 @@ export default class CityManager {
 
 		}
 
+		// The bounding box of the prop depends on its orientation of course.
+		if (orientation % 4 === 1) {
+			[width, depth] = [depth, width];
+		}
+
 		// Create the prop & position correctly.
 		let { terrain } = this.dbpf;
-		let yPos = terrain!.query(0.5*position.x, 0.5*position.z);
+		let yPos = terrain!.query(position.x, *position.z);
 		let y = position.y + yPos;
 		let prop = new Prop({
 			mem: this.mem(),
@@ -704,23 +709,14 @@ export default class CityManager {
 				[position.x+0.5*width, y+height, position.z+0.5*depth],
 			),
 			orientation,
-
-			// Store the TGI of the prop.
-			TID: tgi.type,
-			GID: tgi.group,
-			IID: tgi.instance,
-			IID1: tgi.instance,
+			tgi,
 			OID,
-
 			appearance: 5,
-
-			// Conditional configuration.
 			start,
 			stop,
 			state,
 			condition,
 			timing,
-
 		});
 		prop.tract.update(prop);
 

--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -79,7 +79,7 @@ type AddObjectOptions = {
 	exemplar: ExemplarLike;
 	tgi: TGI;
 	position: Vector3;
-	orientation: number;
+	orientation?: number;
 	OID?: number;
 };
 
@@ -595,7 +595,7 @@ export default class CityManager {
 		exemplar,
 		tgi,
 		position,
-		orientation,
+		orientation = 0,
 		OID = 1,
 	}: AddObjectOptions) {
 

--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -828,6 +828,7 @@ export default class CityManager {
 		// Clear both the lot and zone developer files as well.
 		city.lotDeveloper.clear();
 		city.zoneDeveloper.clear();
+		city.propDeveloper.clear();
 
 		// Clear some simgrids.
 		city.getSimGrid(SimGrid.ZoneData)?.clear();
@@ -868,7 +869,6 @@ function orient(
 		case 0x03:
 			[x, y] = [y, width-x];
 			break;
-
 	}
 
 	// If we didn't request bare coordinates explicitly, transform to city 

--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -379,6 +379,7 @@ export default class CityManager {
 			position,
 			orientation: (lot.orientation+lotObject.orientation) % 4,
 			OID,
+			lotType: 0x02,
 		});
 
 	}
@@ -597,7 +598,8 @@ export default class CityManager {
 		position,
 		orientation = 0,
 		OID = 1,
-	}: AddObjectOptions) {
+		lotType = 0x01,
+	}: AddObjectOptions & { lotType?: number }) {
 
 		// Get the dimensions of the prop bounding box.
 		let size = exemplar.get('OccupantSize');
@@ -700,7 +702,7 @@ export default class CityManager {
 
 		// Create the prop & position correctly.
 		let { terrain } = this.dbpf;
-		let yPos = terrain!.query(position.x, position.z);
+		let yPos = terrain?.query(position.x, position.z) ?? 270;
 		let y = position.y + yPos;
 		let prop = new Prop({
 			mem: this.mem(),
@@ -717,6 +719,7 @@ export default class CityManager {
 			state,
 			condition,
 			timing,
+			lotType,
 		});
 		prop.tract.update(prop);
 

--- a/src/api/get-oriented-position.ts
+++ b/src/api/get-oriented-position.ts
@@ -1,0 +1,34 @@
+// # get-oriented-position.ts
+import { Vector3, type Lot, type LotObject } from 'sc4/core';
+
+type GetOrientedPositionOptions = {
+	lotObject: LotObject;
+	lot: Lot;
+};
+
+// # getOrientedPosition()
+// Accepts a lotObject and returns its position as if the lot were plopped at 
+// tile (0,0) - i.e. the NW corner of a city with the given orientation as the 
+// orientation of the **lot** in the city. Note that this is a bit special 
+// because in the Lot Editor, a lot is shown as having an orientation that would 
+// correspond to orientation 2 in the city - i.e. facing *South*. City 
+// orientation 0 is actually facing *North*, so we have to account for that.
+export default function getOrientedPosition(
+	{ lotObject, lot }: GetOrientedPositionOptions
+): Vector3 {
+	let { x, y, z } = lotObject;
+	let { orientation, width: lotWidth, depth: lotDepth } = lot;
+	let width = 16*lotWidth;
+	let depth = 16*lotDepth;
+	let oid = ((orientation % 4) + 4) % 4 as 0 | 1 | 2 | 3;
+	switch (oid) {
+		case 0x00:
+			return new Vector3(width-x, y, depth-z);
+		case 0x01:
+			return new Vector3(z, y, width-x);
+		case 0x02:
+			return new Vector3(x, y, z);
+		case 0x03:
+			return new Vector3(depth-z, y, x);
+	}
+}

--- a/src/api/plop-all-lots.ts
+++ b/src/api/plop-all-lots.ts
@@ -73,7 +73,7 @@ export default async function plopAllLots(opts: PlopAllLotsOptions)
 
 	// Now loop all files
 	const { bbox } = opts;
-	if (opts.lots) {
+	if (opts.lots !== false) {
 		logger?.progress.start('Plopped 0 lots');
 		let i = 0;
 		for (let file of lots) {

--- a/src/api/plop-all-lots.ts
+++ b/src/api/plop-all-lots.ts
@@ -1,26 +1,25 @@
 // # plop-all-lots.js
 import shuffle from 'knuth-shuffle-seeded';
-import { DBPF, Exemplar, Savegame } from 'sc4/core';
+import { DBPF, Exemplar, ExemplarProperty, Savegame, TGI, Vector3 } from 'sc4/core';
 import { PluginIndex, FileScanner } from 'sc4/plugins';
 import CityManager from './city-manager.js';
 import type { Logger } from 'sc4/types';
-
-const LotConfigPropertySize = 0x88edc790;
 
 // # plopAllLots(files)
 // This function accepts an array of file patterns and will plop all lots that 
 // it finds in those files
 type folder = string;
 type PlopAllLotsOptions = {
-	lots?: string;
+	lots?: string | string[];
 	directory?: folder;
 	installation?: folder;
 	plugins?: folder;
 	logger?: Logger;
-	random?: number | boolean;
+	random?: number | boolean | string;
 	city: string;
 	clear?: boolean;
-	bbox?: [number, number, number, number];
+	bbox?: number[];
+	props?: boolean;
 	save?: boolean;
 	backup?: Function;
 	output?: string;
@@ -47,7 +46,7 @@ export default async function plopAllLots(opts: PlopAllLotsOptions)
 		if (seed === true) {
 			shuffle(lots);
 		} else {
-			shuffle(lots, seed);
+			shuffle(lots, seed as number);
 		}
 	}
 
@@ -72,38 +71,97 @@ export default async function plopAllLots(opts: PlopAllLotsOptions)
 	if (opts.clear) mgr.clear();
 
 	// Now loop all files
-	logger?.progress.start('Plopped 0 lots');
-	let i = 0;
 	const { bbox } = opts;
-	for (let file of lots) {
-		let dbpf = new DBPF({ file, parse: false });
-		await dbpf.parseAsync();
-		for (let entry of dbpf.exemplars) {
+	if (!opts.props) {
+		logger?.progress.start('Plopped 0 lots');
+		let i = 0;
+		for (let file of lots) {
+			let dbpf = new DBPF({ file, parse: false });
+			await dbpf.parseAsync();
+			for (let entry of dbpf.exemplars) {
 
-			// If this is not a lot exemplar, no need to continue.
-			let exemplar = entry.read();
-			if (exemplar.value(0x10) !== 0x10) continue;
-			let pos = findPosition(city, exemplar, bbox);
-			if (!pos) {
-				let name = exemplar.value(0x20);
-				logger?.warn(`Unable to find a suitable position for ${name}`);
-				continue;
-			}
-			let { x, z, orientation } = pos;
-			let result = mgr.grow({
-				tgi: entry.tgi,
-				x,
-				z,
-				orientation,
-			});
-			if (result !== false) {
-				i++;
-				logger?.progress.update(`Plopped ${i} lots`);
+				// If this is not a lot exemplar, no need to continue.
+				let exemplar = entry.read();
+				if (exemplar.value(0x10) !== 0x10) continue;
+				let pos = findPosition(city, exemplar, bbox);
+				if (!pos) {
+					let name = exemplar.value(0x20);
+					logger?.warn(
+						`Unable to find a suitable position for ${name}`,
+					);
+					continue;
+				}
+				let { x, z, orientation } = pos;
+				let result = mgr.grow({
+					tgi: entry.tgi,
+					x,
+					z,
+					orientation,
+				});
+				if (result !== false) {
+					i++;
+					logger?.progress.update(`Plopped ${i} lots`);
+				}
+
 			}
 
 		}
+		logger?.progress.succeed();
 	}
-	logger?.progress.succeed();
+
+	// For the props, we first have to build a data structure that holds which 
+	// 1x1 m² squares are occupied. We do this from the zone developer.
+	if (opts.props) {
+		let { width: cityWidth, depth: cityDepth, zoneDeveloper: zones } = city;
+		let occupiedBuffer = new ArrayBuffer(cityWidth*cityDepth*16**2);
+		let occupied = new Array(16*cityDepth).fill(null).map((_, i) => {
+			let width = 16*cityWidth;
+			return new Uint8Array(occupiedBuffer, i*width, width);
+		});
+		for (let z = 0; z < cityDepth; z++) {
+			for (let x = 0; x < cityWidth; x++) {
+				if (!zones.isOccupied(x, z)) continue;
+				let dx = 16*x;
+				let dz = 16*z;
+				for (let j = 0; j < 16; j++) {
+					for (let i = 0; i < 16; i++) {
+						occupied[dz+j][dx+i] = 1;
+					}
+				}
+			}
+		}
+
+		// Loop all files again, but now look for the props.
+		logger?.progress.start('Added 0 props');
+		let i = 0;
+		for (let file of lots) {
+			let dbpf = new DBPF({ file, parse: false });
+			await dbpf.parseAsync();
+			for (let entry of dbpf.exemplars) {
+				let exemplar = entry.read();
+				let type = exemplar.get('ExemplarType');
+				if (type !== ExemplarProperty.ExemplarType.Prop) continue;
+				let position = findPropPosition(city, occupied, exemplar, bbox);
+				if (!position) {
+					let name = exemplar.get('ExemplarName');
+					logger?.warn(
+						`Unable to find a suitable positoin for prop ${name}`
+					);
+					continue;
+				}
+				let prop = mgr.createProp({
+					exemplar,
+					position,
+					tgi: new TGI(entry.tgi),
+				});
+				if (prop) {
+					i++;
+					logger?.progress.update(`Added ${i} props`);
+				}
+			}
+		}
+		logger?.progress.succeed();
+	}
 
 	// Save at last. If a backup function was specified, we'll first call it.
 	if (opts.save) {
@@ -120,7 +178,7 @@ export default async function plopAllLots(opts: PlopAllLotsOptions)
 // # findPosition(city, exemplar, bbox)
 // Finds a suitable position for the given lot exemplar to plop.
 function findPosition(city: Savegame, exemplar: Exemplar, bbox: number[] = []) {
-	const [width, depth] = exemplar.value(LotConfigPropertySize) as [number, number];
+	const [width, depth] = exemplar.get('LotConfigPropertySize') ?? [0, 0];
 	const { zoneDeveloper: zones, width: cityWidth, depth: cityDepth } = city;
 	const [minX = 0, minZ = 0, maxX = cityWidth, maxZ = cityDepth] = bbox;
 	for (let z = minZ; z <= maxZ-depth; z++) {
@@ -141,6 +199,51 @@ function findPosition(city: Savegame, exemplar: Exemplar, bbox: number[] = []) {
 
 	// If we reach this point, it means no suitable position has been found. 
 	// Pity.
+	return null;
+
+}
+
+// # findPropPosition(city, exemplar, bbox)
+function findPropPosition(
+	city: Savegame,
+	occupied: Uint8Array[],
+	exemplar: Exemplar,
+	bbox: number[] = [],
+) {
+	const s = (x: number) => 16*x;
+	const r = (x: number) => Math.ceil(x);
+	let { width: cityWidth, depth: cityDepth } = city;
+	let [width,, depth] = (exemplar.get('OccupantSize') ?? [0, 0, 0]).map(r);
+	let [
+		minX = 0,
+		minZ = 0,
+		maxX = 16*cityWidth,
+		maxZ = 16*cityDepth,
+	] = bbox.map(s);
+
+	// For the props, we use cells of 1x1 *meters*, but the bbox and city size 
+	// are obviously given in tiles.
+	for (let z = minZ; z <= maxZ-depth; z++) {
+		outer:
+		for (let x = minX; x <= maxX-width; x++) {
+			for (let i = 0; i < width; i++) {
+				for (let j = 0; j < depth; j++) {
+					if (occupied[z+j][x+i]) continue outer;
+				}
+			}
+
+			// If we reach this point, it means there is sufficient space to put 
+			// the prop on. We'll return the position, but we'll also fill up 
+			// the occupied buffer.
+			for (let i = 0; i < width; i++) {
+				for (let j = 0; j < depth; j++) {
+					occupied[z+j][x+i] = 1;
+				}
+			}
+			return new Vector3(x+width/2, 0, z+depth/2);
+
+		}
+	}
 	return null;
 
 }

--- a/src/api/plop-all-lots.ts
+++ b/src/api/plop-all-lots.ts
@@ -10,7 +10,7 @@ import type { Logger } from 'sc4/types';
 // it finds in those files
 type folder = string;
 type PlopAllLotsOptions = {
-	lots?: string | string[];
+	pattern?: string | string[];
 	directory?: folder;
 	installation?: folder;
 	plugins?: folder;
@@ -19,6 +19,7 @@ type PlopAllLotsOptions = {
 	city: string;
 	clear?: boolean;
 	bbox?: number[];
+	lots?: boolean;
 	props?: boolean;
 	save?: boolean;
 	backup?: Function;
@@ -30,13 +31,13 @@ export default async function plopAllLots(opts: PlopAllLotsOptions)
 
 	// First thing we'll do is looking up all lot files with a file scanner.
 	let {
-		lots: pattern = '**/*',
+		pattern = '**/*',
 		directory = process.env.SC4_PLUGINS ?? process.cwd(),
 		logger,
 	} = opts;
 	let lots = await new FileScanner(pattern, { cwd: directory }).walk();
 	if (lots.length === 0) {
-		logger?.warn(`No lots found in files that match the pattern ${pattern} in ${directory}.`);
+		logger?.warn(`No files found that match the pattern ${pattern} in ${directory}.`);
 	}
 
 	// Check if we have to plop the lots in random order.
@@ -72,7 +73,7 @@ export default async function plopAllLots(opts: PlopAllLotsOptions)
 
 	// Now loop all files
 	const { bbox } = opts;
-	if (!opts.props) {
+	if (opts.lots) {
 		logger?.progress.start('Plopped 0 lots');
 		let i = 0;
 		for (let file of lots) {

--- a/src/api/test/city-manager-test.ts
+++ b/src/api/test/city-manager-test.ts
@@ -1,0 +1,242 @@
+// # city-manager-test.ts
+import { Savegame, FileType, Exemplar, TGI, Vector3, SimulatorDate } from 'sc4/core';
+import CityManager from '../city-manager.js';
+import { expect } from 'chai';
+
+describe('The CityManager class', function() {
+
+	describe('#createProp()', function() {
+
+		it('creates a non-conditional prop', function() {
+
+			let exemplar = new Exemplar();
+			exemplar.addProperty('OccupantSize', [4, 1, 5]);
+			let dbpf = new Savegame();
+			let mgr = new CityManager({ dbpf });
+			let tgi = TGI.random(FileType.Exemplar);
+
+			let prop = mgr.createProp({
+				position: new Vector3(5, 0, 5),
+				exemplar,
+				tgi,
+				OID: 4,
+			});
+			expect(prop.bbox[0]).to.eql([3, 270, 2.5]);
+			expect(prop.bbox[1]).to.eql([7, 271, 7.5]);
+			expect(prop.condition).to.equal(0);
+			expect(prop.timing).to.be.null;
+			expect(prop.OID).to.equal(4);
+			expect(prop.start).to.equal(0);
+			expect(prop.stop).to.equal(0);
+			expect(dbpf.COMSerializer.get(FileType.Prop)).to.equal(1);
+
+		});
+
+		it('creates an active date timed prop', function() {
+
+			let exemplar = new Exemplar();
+			exemplar.addProperty('OccupantSize', [4, 4, 4]);
+			exemplar.addProperty('SimulatorDateStart', [3, 1]);
+			exemplar.addProperty('SimulatorDateDuration', 91);
+			exemplar.addProperty('SimulatorDateInterval', 365);
+			let dbpf = Savegame.create({ size: 'small' });
+			dbpf.buffer = dbpf.toBuffer();
+			let { date } = dbpf;
+			date.date = date.date.with({ year: 2001, month: 3, day: 28 });
+			let mgr = new CityManager({ dbpf });
+			let tgi = TGI.random(FileType.Exemplar);
+
+			let prop = mgr.createProp({
+				position: new Vector3(2, 0, 2),
+				exemplar,
+				tgi,
+			});
+			expect(prop.timing).to.be.ok;
+			expect(prop.timing?.start).to.eql(SimulatorDate.fromYearMonthDay(2002, 3, 1));
+			expect(prop.timing?.end).to.eql(SimulatorDate.fromYearMonthDay(2001, 5, 31));
+			expect(prop.timing?.duration).to.equal(91);
+			expect(prop.timing?.interval).to.equal(365);
+			expect(prop.state).to.equal(0);
+			expect(prop.condition).to.equal(0x0f);
+			expect(dbpf.propDeveloper.dateTimedProps).to.have.length(1);
+			expect(dbpf.propDeveloper.dateTimedProps[0].address).to.equal(prop.mem);
+			expect(dbpf.COMSerializer.get(FileType.Prop)).to.equal(1);
+
+		});
+
+		it('creates a date timed prop that will become active', function() {
+
+			let exemplar = new Exemplar();
+			exemplar.addProperty('OccupantSize', [4, 4, 4]);
+			exemplar.addProperty('SimulatorDateStart', [12, 1]);
+			exemplar.addProperty('SimulatorDateDuration', 32);
+			exemplar.addProperty('SimulatorDateInterval', 365);
+			let dbpf = Savegame.create({ size: 'small' });
+			dbpf.buffer = dbpf.toBuffer();
+			let { date } = dbpf;
+			date.date = date.date.with({ year: 2025, month: 11, day: 20 });
+			let mgr = new CityManager({ dbpf });
+			let tgi = TGI.random(FileType.Exemplar);
+
+			let prop = mgr.createProp({
+				position: new Vector3(2, 0, 2),
+				exemplar,
+				tgi,
+			});
+			expect(prop.timing).to.be.ok;
+			expect(prop.timing?.start).to.eql(SimulatorDate.fromYearMonthDay(2025, 12, 1));
+			expect(prop.timing?.end).to.eql(SimulatorDate.fromYearMonthDay(2026, 1, 2));
+			expect(prop.timing?.duration).to.equal(32);
+			expect(prop.timing?.interval).to.equal(365);
+			expect(prop.state).to.equal(1);
+			expect(prop.condition).to.equal(0x0d);
+			expect(dbpf.propDeveloper.dateTimedProps).to.have.length(1);
+			expect(dbpf.propDeveloper.dateTimedProps[0].address).to.equal(prop.mem);
+
+		});
+
+		it('creates a date timed prop that has been active already this year', function() {
+
+			let exemplar = new Exemplar();
+			exemplar.addProperty('OccupantSize', [4, 4, 4]);
+			exemplar.addProperty('SimulatorDateStart', [3, 1]);
+			exemplar.addProperty('SimulatorDateDuration', 91);
+			exemplar.addProperty('SimulatorDateInterval', 365);
+			let dbpf = Savegame.create({ size: 'small' });
+			dbpf.buffer = dbpf.toBuffer();
+			let { date } = dbpf;
+			date.date = date.date.with({ year: 2025, month: 11, day: 20 });
+			let mgr = new CityManager({ dbpf });
+			let tgi = TGI.random(FileType.Exemplar);
+
+			let prop = mgr.createProp({
+				position: new Vector3(2, 0, 2),
+				exemplar,
+				tgi,
+			});
+			expect(prop.timing).to.be.ok;
+			expect(prop.timing?.start).to.eql(SimulatorDate.fromYearMonthDay(2026, 3, 1));
+			expect(prop.timing?.end).to.eql(SimulatorDate.fromYearMonthDay(2026, 5, 31));
+			expect(prop.timing?.duration).to.equal(91);
+			expect(prop.timing?.interval).to.equal(365);
+			expect(prop.state).to.equal(1);
+			expect(prop.condition).to.equal(0x0d);
+			expect(dbpf.propDeveloper.dateTimedProps).to.have.length(1);
+			expect(dbpf.propDeveloper.dateTimedProps[0].address).to.equal(prop.mem);
+
+		});
+
+		it('creates an active hour timed prop', function() {
+
+			let exemplar = new Exemplar();
+			exemplar.addProperty('OccupantSize', [4, 4, 4]);
+			exemplar.addProperty('PropTimeOfDay', [12, 15]);
+			let dbpf = Savegame.create({ size: 'medium' });
+			dbpf.buffer = dbpf.toBuffer();
+			let { clock } = dbpf;
+			clock.secondOfDay = 13*3600;
+
+			let mgr = new CityManager({ dbpf });
+			let tgi = TGI.random(FileType.Exemplar);
+
+			let prop = mgr.createProp({
+				position: new Vector3(2, 0, 2),
+				exemplar,
+				tgi,
+			});
+			expect(prop.timing).to.be.null;
+			expect(prop.start).to.equal(120);
+			expect(prop.stop).to.equal(150);
+			expect(prop.state).to.equal(0);
+			expect(prop.condition).to.equal(0x0f);
+			expect(prop.lotType).to.equal(0x01);
+			expect(dbpf.propDeveloper.hourTimedProps).to.have.length(1);
+			expect(dbpf.propDeveloper.hourTimedProps[0].address).to.equal(prop.mem);
+
+		});
+
+		it('creates an non-active hour timed prop', function() {
+
+			let exemplar = new Exemplar();
+			exemplar.addProperty('OccupantSize', [4, 4, 4]);
+			exemplar.addProperty('PropTimeOfDay', [15, 12]);
+			let dbpf = Savegame.create({ size: 'medium' });
+			dbpf.buffer = dbpf.toBuffer();
+			let { clock } = dbpf;
+			clock.secondOfDay = 13*3600;
+
+			let mgr = new CityManager({ dbpf });
+			let tgi = TGI.random(FileType.Exemplar);
+
+			let prop = mgr.createProp({
+				position: new Vector3(2, 0, 2),
+				exemplar,
+				tgi,
+				lotType: 0x02,
+			});
+			expect(prop.timing).to.be.null;
+			expect(prop.start).to.equal(150);
+			expect(prop.stop).to.equal(120);
+			expect(prop.state).to.equal(1);
+			expect(prop.condition).to.equal(0x0e);
+			expect(prop.lotType).to.equal(0x02);
+			expect(dbpf.propDeveloper.hourTimedProps).to.have.length(1);
+			expect(dbpf.propDeveloper.hourTimedProps[0].address).to.equal(prop.mem);
+
+		});
+
+		it('creates an active night timed prop', function() {
+
+			let exemplar = new Exemplar();
+			exemplar.addProperty('OccupantSize', [1, 1, 1]);
+			exemplar.addProperty('NighttimeStateChange', 1);
+			let dbpf = Savegame.create({ size: 'large' });
+			dbpf.buffer = dbpf.toBuffer();
+
+			let mgr = new CityManager({ dbpf });
+			let tgi = TGI.random(FileType.Exemplar);
+			let { clock } = dbpf;
+			clock.secondOfDay = 23*3600;
+
+			let prop = mgr.createProp({
+				position: new Vector3(0, 0, 0),
+				exemplar,
+				tgi,
+			});
+			expect(prop.state).to.equal(1);
+			expect(prop.condition).to.equal(0);
+			expect(dbpf.propDeveloper.nightTimedProps).to.have.length(1);
+			expect(dbpf.propDeveloper.nightTimedProps[0].address).to.be.above(0);
+			expect(dbpf.propDeveloper.nightTimedProps[0].address).to.equal(prop.mem);
+
+		});
+
+		it('creates an deactivated night timed prop', function() {
+
+			let exemplar = new Exemplar();
+			exemplar.addProperty('OccupantSize', [1, 1, 1]);
+			exemplar.addProperty('NighttimeStateChange', 1);
+			let dbpf = Savegame.create({ size: 'large' });
+			dbpf.buffer = dbpf.toBuffer();
+
+			let mgr = new CityManager({ dbpf });
+			let tgi = TGI.random(FileType.Exemplar);
+			let { clock } = dbpf;
+			clock.secondOfDay = 11*3600;
+
+			let prop = mgr.createProp({
+				position: new Vector3(0, 0, 0),
+				exemplar,
+				tgi,
+			});
+			expect(prop.state).to.equal(0);
+			expect(prop.condition).to.equal(0);
+			expect(dbpf.propDeveloper.nightTimedProps).to.have.length(1);
+			expect(dbpf.propDeveloper.nightTimedProps[0].address).to.be.above(0);
+			expect(dbpf.propDeveloper.nightTimedProps[0].address).to.equal(prop.mem);
+
+		});
+
+	});
+
+});

--- a/src/api/test/get-oriented-position-test.ts
+++ b/src/api/test/get-oriented-position-test.ts
@@ -1,0 +1,48 @@
+// # get-oriented-position-test.ts
+import { Lot, LotObject, Vector3 } from 'sc4/core';
+import getOrientedPosition from '../get-oriented-position.js';
+import { expect } from 'chai';
+
+describe('#getOrientedPosition()', function() {
+
+	it('orientation 0', function() {
+
+		let lot = new Lot({
+			width: 3,
+			depth: 1,
+			orientation: 0,
+		});
+		let lotObject = new LotObject({ x: 0, z: 0 });
+		let position = getOrientedPosition({ lot, lotObject });
+		expect(position).to.eql(new Vector3(3*16, 0, 16));
+
+	});
+
+	it('orientation 1', function() {
+
+		let lot = new Lot({ width: 1, depth: 4, orientation: 1 });
+		let lotObject = new LotObject({ x: 8, z: 4*16 });
+		let position = getOrientedPosition({ lot, lotObject });
+		expect(position).to.eql(new Vector3(4*16, 0, 8));
+
+	});
+
+	it('orientation 2', function() {
+
+		let lot = new Lot({ width: 5, depth: 3, orientation: 2 });
+		let lotObject = new LotObject({ x: 1, z: 16 });
+		let position = getOrientedPosition({ lot, lotObject });
+		expect(position).to.eql(new Vector3(1, 0, 16));
+
+	});
+
+	it('orientation 3', function() {
+
+		let lot = new Lot({ width: 8, depth: 16, orientation: 3 });
+		let lotObject = new LotObject({ x: 3*16, y: 1, z: 1 });
+		let position = getOrientedPosition({ lot, lotObject });
+		expect(position).to.eql(new Vector3(16*16-1, 1, 3*16));
+
+	});
+
+});

--- a/src/api/test/plop-all-test.ts
+++ b/src/api/test/plop-all-test.ts
@@ -14,7 +14,7 @@ describe('The plopall api function', function() {
 		let diego = resource('DiegoDL-432ParkAvenue-LM-DN');
 		let dbpf = await plopAll({
 			city,
-			lots: '*.SC4Lot',
+			pattern: '*.SC4Lot',
 			directory: diego,
 			plugins: diego,
 			save: false,

--- a/src/cli/commands/plop-all-command.ts
+++ b/src/cli/commands/plop-all-command.ts
@@ -10,13 +10,14 @@ type PlopAllCommandOptions = {
 	clear?: boolean;
 	random?: string;
 	bbox?: string;
+	lots?: boolean;
 	props?: boolean;
 };
 
 // # plopAll()
 export async function plopAll(
 	city: string,
-	lots: string[],
+	pattern: string[],
 	options: PlopAllCommandOptions = {},
 ) {
 
@@ -26,6 +27,7 @@ export async function plopAll(
 		random = undefined,
 		bbox: bboxString,
 		props,
+		lots,
 	} = options;
 
 	// The bbox still needs to be parsed it is given.
@@ -34,12 +36,13 @@ export async function plopAll(
 		bbox = parseList(bboxString.replaceAll(/[[\]]/g, '')).map(x => +x);
 	}
 	await plop({
-		lots,
+		pattern,
 		directory,
 		city: path.resolve(process.env.SC4_REGIONS ?? process.cwd(), city),
 		clear,
 		bbox,
 		random,
+		lots,
 		props,
 		save: true,
 		logger,

--- a/src/cli/commands/plop-all-command.ts
+++ b/src/cli/commands/plop-all-command.ts
@@ -5,19 +5,33 @@ import logger from '#cli/logger.js';
 import backup from '#cli/backup.js';
 import parseList from '#cli/helpers/parse-list.js';
 
+type PlopAllCommandOptions = {
+	directory?: string;
+	clear?: boolean;
+	random?: string;
+	bbox?: string;
+	props?: boolean;
+};
+
 // # plopAll()
-export async function plopAll(city, lots, options = {}) {
+export async function plopAll(
+	city: string,
+	lots: string[],
+	options: PlopAllCommandOptions = {},
+) {
 
 	let {
 		directory,
 		clear = false,
 		random = undefined,
-		bbox,
+		bbox: bboxString,
+		props,
 	} = options;
 
 	// The bbox still needs to be parsed it is given.
-	if (bbox) {
-		bbox = parseList(bbox.replaceAll(/[[\]]/g, '')).map(x => +x);
+	let bbox: number[] | undefined;
+	if (bboxString) {
+		bbox = parseList(bboxString.replaceAll(/[[\]]/g, '')).map(x => +x);
 	}
 	await plop({
 		lots,
@@ -26,6 +40,7 @@ export async function plopAll(city, lots, options = {}) {
 		clear,
 		bbox,
 		random,
+		props,
 		save: true,
 		logger,
 		backup,

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -92,6 +92,7 @@ export function factory(program) {
 		.option('--clear', 'Clears the existing items in the city')
 		.option('-d, --directory <dir>', 'The directory to match the patterns against. Defaults to you configured plugins folder')
 		.option('--random [seed]', 'Plops the lots in random order, optionally with a seed for reproducability')
+		.option('--no-lots', 'Don\'t plop any lots. Useful in combination with --props')
 		.option('--props', 'Plops all props instead of lots')
 		.action(commands.plopAll);
 

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -89,9 +89,10 @@ export function factory(program) {
 		.command('plop <city> [patterns...]')
 		.description(`Plops all lots that match the patterns in the city. DO NOT use this on established cities!`)
 		.option('--bbox <bbox>', 'The bounding box to plop the lots in, given as minX,minZ,maxX,maxZ. Defaults to the entire city.')
-		.option('--clear', 'Clears the existing lots in the city')
+		.option('--clear', 'Clears the existing items in the city')
 		.option('-d, --directory <dir>', 'The directory to match the patterns against. Defaults to you configured plugins folder')
 		.option('--random [seed]', 'Plops the lots in random order, optionally with a seed for reproducability')
+		.option('--props', 'Plops all props instead of lots')
 		.action(commands.plopAll);
 
 	city

--- a/src/core/csc4-city.ts
+++ b/src/core/csc4-city.ts
@@ -26,7 +26,7 @@ export default class cSC4City {
 	physicalSize = [1024, 1024];
 	physicalTileSize = [16, 16];
 	tilesPerMeter: [float, float] = [1/16, 1/16];
-	size: [number, number] = [0x40, 0x40];
+	size: [number, number] = [64, 64];
 	pointers: Pointer[] = [];
 	u = new Unknown()
 		.dword(0x00000000)

--- a/src/core/csc4-simulator.ts
+++ b/src/core/csc4-simulator.ts
@@ -10,7 +10,7 @@ import SimulatorDate from './simulator-date.js';
 export default class cSC4Simulator {
 	static [kFileType] = FileType.cSC4Simulator;
 	crc: dword = 0x00000000;
-	mem:dword = 0x00000000;
+	mem: dword = 0x00000000;
 	version = '4';
 	hoursPerDay: dword = 24;
 	dayOfYear: dword = 1;

--- a/src/core/exemplar.ts
+++ b/src/core/exemplar.ts
@@ -672,6 +672,7 @@ class Property<K extends Key = Key> {
 // # cast(type, value)
 // Ensures a value specified for a property matches its specified type.
 function cast(type: PropertyValueType, value: ValueType): ValueType {
+	if (typeof value === 'undefined') return value;
 	if (Array.isArray(value)) {
 		return value.map(value => cast(type, value)) as Primitive[];
 	}

--- a/src/core/exemplar.ts
+++ b/src/core/exemplar.ts
@@ -23,6 +23,10 @@ import TGI from './tgi.js';
 
 type ExemplarId = 'EQZB1###' | 'EQZT1###' | 'CQZB1###' | 'CQZT###';
 
+export type ExemplarLike = {
+	get<K extends Key = Key>(key: K): Value<K> | undefined;
+};
+
 export type ExemplarOptions = {
 	id?: ExemplarId;
 	parent?: TGILike;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,7 +18,7 @@ export { default as SimulatorDate } from './simulator-date.js';
 export { default as Color } from './color.js';
 export { default as Vertex } from './vertex.js';
 export { default as Pointer } from './pointer.js';
-export { default as Vector3 } from './vector-3.js';
+export { default as Vector3, type Vector3Like } from './vector-3.js';
 export { default as Box3 } from './box-3.js';
 export { default as NetworkCrossing } from './network-crossing.js';
 export { NetworkIndexTile } from './network-index.js';
@@ -45,3 +45,4 @@ export type {
 export type {
 	Key as ExemplarPropertyKey,
 } from './exemplar-properties-types.js';
+export type { ExemplarLike } from './exemplar.js';

--- a/src/core/item-index.ts
+++ b/src/core/item-index.ts
@@ -57,6 +57,7 @@ export default class ItemIndex {
 
 	// ## get(x: number, z: number)
 	get(x: number, z: number): Cell | undefined {
+		this.ensure();
 		let column = this.elements[x];
 		if (!column) return undefined;
 		return column.at(z);
@@ -121,6 +122,12 @@ export default class ItemIndex {
 		return this;
 	}
 
+	// ## ensure()
+	ensure() {
+		if (this.elements.length === 0) this.fill();
+		return this;
+	}
+
 	// ## clear()
 	clear() {
 		this.fill();
@@ -132,6 +139,7 @@ export default class ItemIndex {
 	// item needs to expose min and max tract coordinates, but they do so 
 	// quite often!
 	add(item: SavegameObject, type = getClassType(item)) {
+		this.ensure();
 		let { tract } = item;
 		for (let x = tract.minX; x <= tract.maxX; x++) {
 			for (let z = tract.minZ; z <= tract.maxZ; z++) {

--- a/src/core/lot-object.ts
+++ b/src/core/lot-object.ts
@@ -1,5 +1,4 @@
 // # lot-object.js
-const scale = 0x00100000;
 import type { ConstructorOptions, MinLengthArray, uint32 } from 'sc4/types';
 import { inspect } from 'sc4/utils';
 import type { ValueOf } from 'type-fest';
@@ -8,6 +7,9 @@ export type LotObjectTypeId = ValueOf<typeof LotObjectType>;
 export type LotObjectArray = [LotObjectTypeId, ...MinLengthArray<uint32, 11>];
 export type LotObjectOptions = ConstructorOptions<LotObject> | LotObjectArray;
 
+// The scale is used to transform the coordinates as stored in the exemplar to 
+// **meters**. That's the most intuitive to work with.
+const scale = 0x00010000;
 const LotObjectType = {
 	Building: 0x00,
 	Prop: 0x01,
@@ -75,10 +77,10 @@ export default class LotObject {
 				x: x/scale,
 				y: y/scale,
 				z: z/scale,
-				minX: 16*signed(minX)/scale,
-				minZ: 16*signed(minZ)/scale,
-				maxX: 16*signed(maxX)/scale,
-				maxZ: 16*signed(maxZ)/scale,
+				minX: signed(minX)/scale,
+				minZ: signed(minZ)/scale,
+				maxX: signed(maxX)/scale,
+				maxZ: signed(maxZ)/scale,
 				usage,
 				OID,
 				IIDs: rest,
@@ -114,10 +116,10 @@ export default class LotObject {
 			Math.round(scale*x),
 			Math.round(scale*y),
 			Math.round(scale*z),
-			uint(scale*minX/16),
-			uint(scale*minZ/16),
-			uint(scale*maxX/16),
-			uint(scale*maxZ/16),
+			uint(scale*minX),
+			uint(scale*minZ),
+			uint(scale*maxX),
+			uint(scale*maxZ),
 			usage,
 			OID,
 		];

--- a/src/core/prop-developer.ts
+++ b/src/core/prop-developer.ts
@@ -32,11 +32,11 @@ export default class PropDeveloper {
 	count2: number = 0;
 	count3: number = 0;
 	count4: number = 0;
-	nightTimedProps: Pointer[];
-	array2: AdviceRecord[];
-	hourTimedProps: Pointer[];
-	dateTimedProps: Pointer[];
-	array5: Pointer[];
+	nightTimedProps: Pointer[] = [];
+	array2: AdviceRecord[] = [];
+	hourTimedProps: Pointer[] = [];
+	dateTimedProps: Pointer[] = [];
+	array5: Pointer[] = [];
 	u = new Unknown()
 		.bytes([2, 1])
 		.dword()

--- a/src/core/prop-developer.ts
+++ b/src/core/prop-developer.ts
@@ -127,4 +127,15 @@ export default class PropDeveloper {
 		unknown.byte();
 		return ws.seal();
 	}
+
+	// ## clear()
+	clear() {
+		this.nightTimedProps = [];
+		this.array2 = [];
+		this.hourTimedProps = [];
+		this.dateTimedProps = [];
+		this.array5 = [];
+		return this;
+	}
+
 }

--- a/src/core/prop.ts
+++ b/src/core/prop.ts
@@ -9,6 +9,7 @@ import Box3 from './box-3.js';
 import TractInfo from './tract-info.js';
 import type { Vector3Like } from './vector-3.js';
 import type SimulatorDate from './simulator-date.js';
+import TGI from './tgi.js';
 
 type Timing = {
 	interval: number;
@@ -32,9 +33,7 @@ export default class Prop {
 	unknown2 = 0xA823821E;
 	tract = new TractInfo();
 	sgprops: SGProp[] = [];
-	GID = 0x00000000;
-	TID = 0x00000000;
-	IID = 0x00000000;
+	tgi = new TGI();
 	IID1 = 0x00000000;
 	bbox = new Box3();
 	orientation = 0x00;
@@ -72,17 +71,13 @@ export default class Prop {
 		this.unknown2 = rs.dword();
 		this.tract = rs.tract();
 		this.sgprops = rs.sgprops();
-		this.GID = rs.dword();
-		this.TID = rs.dword();
-		this.IID = rs.dword();
+		this.tgi = rs.gti();
 		this.IID1 = rs.dword();
 		this.bbox = rs.bbox();
 		this.orientation = rs.byte();
 		this.state = rs.byte();
 		this.start = rs.byte();
 		this.stop = rs.byte();
-
-		// Parse interal.
 		let count = rs.byte();
 		if (count) {
 			this.timing = {
@@ -92,7 +87,6 @@ export default class Prop {
 				end: rs.date(),
 			};
 		}
-
 		this.chance = rs.byte();
 		this.lotType = rs.byte();
 		this.OID = rs.dword();
@@ -116,9 +110,7 @@ export default class Prop {
 		ws.dword(this.unknown2);
 		ws.tract(this.tract);
 		ws.array(this.sgprops);
-		ws.dword(this.GID);
-		ws.dword(this.TID);
-		ws.dword(this.IID);
+		ws.gti(this.tgi);
 		ws.dword(this.IID1);
 		ws.bbox(this.bbox);
 		ws.byte(this.orientation);

--- a/src/core/prop.ts
+++ b/src/core/prop.ts
@@ -49,8 +49,8 @@ export default class Prop {
 	// ## constructor(opts)
 	constructor(opts: ConstructorOptions<Prop> = {}) {
 		let {
-			tgi = new TGI(),
-			IID1 = tgi.instance ?? 0x00000000,
+			tgi = this.tgi,
+			IID1 = tgi.instance,
 			...rest
 		} = opts;
 		Object.assign(this, rest);

--- a/src/core/prop.ts
+++ b/src/core/prop.ts
@@ -47,8 +47,15 @@ export default class Prop {
 	condition = 0x00;
 
 	// ## constructor(opts)
-	constructor(opts?: ConstructorOptions<Prop>) {
-		Object.assign(this, opts);
+	constructor(opts: ConstructorOptions<Prop> = {}) {
+		let {
+			tgi = new TGI(),
+			IID1 = tgi.instance ?? 0x00000000,
+			...rest
+		} = opts;
+		Object.assign(this, rest);
+		this.tgi = tgi;
+		this.IID1 = IID1;
 	}
 
 	// ## move()

--- a/src/core/region-view.ts
+++ b/src/core/region-view.ts
@@ -42,10 +42,19 @@ export default class RegionView {
 	unknownFloats: float[] = [];
 	neighbourConnections: NeighbourConnection[] = [];
 	u = new Unknown()
-		.dword(0x00000000)
+		.float(0)
 		.repeat(5, u => u.dword(0x00000000))
 		.repeat(5, u => u.dword(0x00000000))
-		.dword(0xffffffff);
+		.dword(0xffffffff)
+		.array()
+		.dword()
+		.float(0)
+		.dword()
+		.float(0)
+		.array()
+		.array()
+		.array()
+		.array();
 
 	// ## parse(buff)
 	// Partially read in. This stuff is pretty much read-only for now, no 

--- a/src/core/savegame.ts
+++ b/src/core/savegame.ts
@@ -93,13 +93,13 @@ export default class Savegame extends DBPF {
 	// Getter for easily accessing the width of the city. We read this from the 
 	// terrain map.
 	get width() {
-		return this.regionView.xSize;
+		return 64*this.regionView.xSize;
 	}
 
 	// ## get depth()
 	// Same for the city depth.
 	get depth() {
-		return this.regionView.zSize;
+		return 64*this.regionView.zSize;
 	}
 
 	// ## createContext()
@@ -166,7 +166,7 @@ export default class Savegame extends DBPF {
 	static create(opts: SavegameCreateOptions) {
 
 		// The first file we'll add is the region view.
-		let size = ({ small: 64, medium: 128, large: 256 })[opts.size];
+		let size = ({ small: 1, medium: 2, large: 4 })[opts.size];
 		let group = randomId();
 		let dbpf = new Savegame();
 		let regionView = new RegionView();

--- a/src/core/test/region-view-test.ts
+++ b/src/core/test/region-view-test.ts
@@ -20,7 +20,7 @@ describe('The RegionView subfile', function() {
 		expect(view.neighbourConnections).to.have.length(0);
 	});
 
-	it.only('parses a large developed tile', function() {
+	it('parses a large developed tile', function() {
 		let dbpf = new Savegame(resource('City - Large developed.sc4'));
 		let entry = dbpf.find({ type: FileType.RegionView })!;
 		let view = entry.read();

--- a/src/core/test/region-view-test.ts
+++ b/src/core/test/region-view-test.ts
@@ -10,6 +10,8 @@ describe('The RegionView subfile', function() {
 		let dbpf = new Savegame(resource('City - Empty small tile.sc4'));
 		let entry = dbpf.find({ type: FileType.RegionView })!;
 		let view = entry.read();
+		expect(view.xSize).to.equal(1);
+		expect(view.xSize).to.equal(1);
 		expect(view.population).to.eql({
 			residential: 0,
 			commercial: 0,
@@ -24,6 +26,8 @@ describe('The RegionView subfile', function() {
 		let dbpf = new Savegame(resource('City - Large developed.sc4'));
 		let entry = dbpf.find({ type: FileType.RegionView })!;
 		let view = entry.read();
+		expect(view.xSize).to.equal(4);
+		expect(view.xSize).to.equal(4);
 		expect(view.population).to.eql({
 			residential: 34639,
 			commercial: 5541,

--- a/src/core/test/savegame-test.ts
+++ b/src/core/test/savegame-test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import Savegame from '../savegame.js';
+import path from 'node:path';
+
+// # savegame-test.ts
+describe('A Savegame', function() {
+
+	describe('#Savegame.create()', function() {
+
+		it('creates an empty savegame', function() {
+
+			const dbpf = Savegame.create({ size: 'small' });
+			dbpf.save(path.join(process.env.SC4_REGIONS!, 'suburb/City - nw.sc4'))
+			expect(dbpf.width).to.equal(64);
+			expect(dbpf.depth).to.equal(64);
+
+		});
+
+	});
+
+});

--- a/src/core/test/savegame-test.ts
+++ b/src/core/test/savegame-test.ts
@@ -10,7 +10,6 @@ describe('A Savegame', function() {
 		it('creates an empty savegame', function() {
 
 			const dbpf = Savegame.create({ size: 'small' });
-			dbpf.save(path.join(process.env.SC4_REGIONS!, 'suburb/City - nw.sc4'))
 			expect(dbpf.width).to.equal(64);
 			expect(dbpf.depth).to.equal(64);
 

--- a/src/core/unknown.ts
+++ b/src/core/unknown.ts
@@ -23,7 +23,7 @@ export default class Unknown extends Array<UnknownType> {
 		}
 		return this;
 	}
-	array(value: UnknownType[]) { this.push(value); return this; }
+	array(value: UnknownType[] = []) { this.push(value); return this; }
 
 	// ## repeat()
 	// Helper for repeating a certain pattern a few times.

--- a/src/plugins/test/plugin-index-test.ts
+++ b/src/plugins/test/plugin-index-test.ts
@@ -28,9 +28,9 @@ describe('The plugin index', function() {
 		expect(file.prop(0x88EDC900)).to.be.ok;
 
 		let building = file.lotObjects.find(x => x.type === 0x00)!;
-		expect(building.x).to.equal(1);
+		expect(building.x).to.equal(16);
 		expect(building.y).to.equal(0);
-		expect(building.z).to.equal(1.5);
+		expect(building.z).to.equal(24);
 
 	});
 


### PR DESCRIPTION
This PR refactors the way that props are created when programmatically plopping lots. This allows them to be added to a city without being part of a lot as well. Due to this change, it is now possible to plop all props from a collection as well, using the `--props` flag in the `sc4 city plop` command.

Examples:
```sh
# Plop all lots and props from the folder "some/plugin" in the given city
sc4 city plop "Region/City - empty tile.sc4" some/plugin/**/* --props --clear --bbox 32,32,64,128

# Plop all bsc props that have been installed with sc4pac, ignoring any lots
sc4 city plop "Region/City - empty tile.sc4" bsc:* --props --no-lots

# Plop all props from the bsc:mega-props-cp-vol01 package
sc4 city plop "Region/City - empty tile.sc4" bsc:mega-props-cp-vol01 --props
```