### PR TITLE
feat: add `sc4 plugins duplicates` command

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -2,7 +2,7 @@
 // Contains the JavaScript api of the cli. This separates concerns nicely: the 
 // api does the actual job, while the cli is merely responsible for the 
 // options parsing.
-import { fs, path, crypto } from 'sc4/utils';
+import { fs } from 'sc4/utils';
 import { Savegame, SimGrid } from 'sc4/core';
 
 // # historical(opts)
@@ -129,47 +129,6 @@ export async function growify(opts = {}) {
 
 }
 
-// # duplicates(opts)
-// Finds duplicates files in a plugin folder.
-export function duplicates(opts) {
-	let {
-		logger = defaultLogger,
-		folder,
-	} = opts;
-	let start = path.resolve(process.cwd(), folder);
-	let map = new Map();
-
-	function dive(dir) {
-		let contents = fs.readdirSync(dir);
-		for (let entry of contents) {
-			entry = path.join(dir, entry);
-			let stat = fs.statSync(entry);
-			if (stat.isDirectory()) {
-				dive(entry);
-			} else {
-				let buffer = fs.readFileSync(entry);
-				let sha = hash(buffer);
-				if (map.has(sha)) {
-					let arr = map.get(sha);
-					arr.push(entry);
-				} else {
-					map.set(sha, [entry]);
-				}
-			}
-		}
-	}
-	logger.info('Reading plugins folder');
-	dive(start);
-
-	// Now log all duplicates.
-	for (let files of map.values()) {
-		if (files.length === 1) continue;
-		let out = files.map(full => path.relative(start, full));
-		console.log(out);
-	}
-
-}
-
 // An object containing some default options, such as the logging functions 
 // etc.
 const defaultLogger = {
@@ -192,11 +151,3 @@ function open(dbpf) {
 // # noop()
 // Does nothing.
 function noop() {}
-
-// # hash(buffer)
-// Returns the sha256 hash of a buffer.
-function hash(buffer) {
-	const hash = crypto.createHash('sha256');
-	hash.update(buffer);
-	return hash.digest('hex');
-}

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -14,3 +14,4 @@ export * from './submenu-unpack-command.js';
 export * from './dbpf-extract-command.js';
 export * from './dbpf-add-command.js';
 export * from './city-count-command.js';
+export * from './plugins-duplicates-command.js';

--- a/src/cli/commands/plugins-duplicates-command.ts
+++ b/src/cli/commands/plugins-duplicates-command.ts
@@ -1,0 +1,76 @@
+// # plugins-duplicates-command.ts
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import PQueue from 'p-queue';
+import { FileScanner } from 'sc4/plugins';
+import logger from '#cli/logger.js';
+import { styleText } from 'node:util';
+
+type FileInfo = {
+	hash: string;
+	basename: string;
+	path: string;
+};
+
+export async function pluginsDuplicates(opts: { directory: string }) {
+	const {
+		directory = process.env.SC4_PLUGINS!,
+	} = opts;
+	const cwd = path.resolve(process.cwd(), directory);
+	const glob = new FileScanner('**/*', { cwd });
+	let info: FileInfo[] = [];
+	const map: Record<string, number> = {};
+	const queue = new PQueue({ concurrency: 250 });
+	logger.progress.start('Scanning plugins');
+	for await (let file of glob) {
+		queue.add(async () => {
+			let contents = await fs.promises.readFile(file);
+			let hash = createHash('sha256')
+				.update(contents)
+				.digest('hex');
+			let basename = path.basename(file);
+			info.push({
+				hash,
+				basename,
+				path: path.relative(cwd, file),
+			});
+			map[hash] ??= 0;
+			map[hash]++;
+		});
+	}
+	await queue.onIdle();
+	logger.progress.succeed();
+
+	// Fiter out anything that has a unique hash.
+	info = info.filter(info => map[info.hash]! > 1);
+	info.sort((a, b) => a.path < b.path ? -1 : 1);
+
+	// Cool, everything has been scanned. Let's group based on filename, and the 
+	// subgroup by hash.
+	let table: any = [];
+	let grouped = Object.groupBy(info, info => info.hash);
+	for (let hash of Object.keys(grouped)) {
+		let group = grouped[hash]!;
+		for (let i = 0; i < group.length; i++) {
+			let info = group[i];
+			table.push({
+				...i === 0 ? {
+					hash: {
+						[Symbol.for('nodejs.util.inspect.custom')]() {
+							return styleText('yellow', hash.slice(0, 9));
+						},
+					},
+				} : null,
+				file: {
+					[Symbol.for('nodejs.util.inspect.custom')]() {
+						return styleText('cyan', info.path);
+					},
+				},
+			});
+		}
+		table.push({});
+	}
+	console.table(table, ['hash', 'file']);
+
+}

--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -16,15 +16,15 @@ export default {
 			prefix = '\r';
 		},
 		update: (text: string) => void (spinner.text = text),
-		succeed: (text: string) => {
+		succeed: (text?: string) => {
 			spinner.succeed(text);
 			prefix = '';
 		},
-		fail: (text: string) => {
+		fail: (text?: string) => {
 			spinner.fail(text);
 			prefix = '';
 		},
-		warn: (text: string) => {
+		warn: (text?: string) => {
 			spinner.warn(text);
 			prefix = '';
 		},

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -169,6 +169,13 @@ export function factory(program) {
 		.option('--tree', 'Shows the entire dependency tree')
 		.action(commands.track);
 
+	// Command for finding duplicate files in a plugin folder.
+	plugins
+		.command('duplicates')
+		.description('Finds all duplicate files in a folder by comparing their contents')
+		.option('-d, --directory <dir>', 'The directory to look for duplicates in. Defaults to your configured plugins folder')
+		.action(commands.pluginsDuplicates);
+
 	// Commands that operate specifically on dbpfs, such as extracting a DBPF.
 	const dbpf = program
 		.command('dbpf')
@@ -532,17 +539,6 @@ export function factory(program) {
 			opts.info(`Saving to ${ output }`);
 			await dbpf.save({ file: output });
 
-		});
-
-	// Command for finding duplicate files in a plugin folder.
-	misc
-		.command('duplicates <folder>')
-		.storeOptionsAsProperties()
-		.action(function(folder) {
-			api.duplicates({
-				...baseOptions(),
-				folder,
-			});
 		});
 
 	const config = program


### PR DESCRIPTION
The old `sc4 misc duplicates` command has been reworked so that we now show a nice table of all the duplicates in a given folder, which defaults to the user's configured plugins folder.