### PR TITLE
fix: handle query guids with same IID as building exemplar

### DIFF
--- a/src/plugins/dependency-tracker.ts
+++ b/src/plugins/dependency-tracker.ts
@@ -574,7 +574,7 @@ class DependencyTrackingContext {
 		const props = {
 			UserVisibleNameKey: { type: FileType.LTEXT },
 			ItemIcon: { type: FileType.PNG, group: 0x6a386d26 },
-			QueryExemplarGUID: {},
+			QueryExemplarGUID: { type: 0x00000000 },
 			SFXQuerySound: { type: 0x0b8d821a },
 			SFXDefaultPlopSound: { type: 0x0b8d821a },
 			SFXAmbienceGoodSound: { type: 0x0b8d821a },

--- a/src/plugins/dependency-types.ts
+++ b/src/plugins/dependency-types.ts
@@ -368,7 +368,11 @@ export class Exemplar extends Dependency {
 			));
 		}
 		if (this.parent) {
-			lines.push(...this.parent.toLines({ width, level: level+1 }));
+			let s = ' '.repeat(2*(level+1));
+			lines.push(
+				`${s}${chalk.green('Parent')}`,
+				...this.parent.toLines({ width, level: level+1, root: false }),
+			);
 		}
 		if (root) lines.push('');
 		return lines;

--- a/src/plugins/test/dependency-tracker-test.ts
+++ b/src/plugins/test/dependency-tracker-test.ts
@@ -9,22 +9,72 @@ import { expect } from 'chai';
 
 describe('#DependencyTracker', function() {
 
-	it('does not track props added to a Maxis family as dependencies (#77)', async function() {
-
+	async function setup() {
 		let folder = output('deps');
 		await fs.promises.rm(folder, { recursive: true, force: true });
-		let core = path.join(folder, 'core');
+		let installation = path.join(folder, 'installation');
 		let plugins = path.join(folder, 'plugins');
-		await fs.promises.mkdir(core, { recursive: true });
+		await fs.promises.mkdir(installation, { recursive: true });
 		await fs.promises.mkdir(plugins, { recursive: true });
+		return { installation, plugins };
+	}
 
+	it('tracks dependencies starting from a lot', async function() {
+
+		let { installation, plugins } = await setup();
+
+		let model = new DBPF();
+		let modelTGI = TGI.random(FileType.S3D);
+		model.add(modelTGI, new Uint8Array());
+		model.save(path.join(plugins, 'model.SC4Model'));
+
+		let building = new DBPF();
+		let buildingExemplar = new Exemplar();
+		buildingExemplar.addProperty('ExemplarType', ExemplarProperty.ExemplarType.Buildings);
+		buildingExemplar.addProperty('ResourceKeyType0', [...modelTGI]);
+		buildingExemplar.addProperty('ExemplarName', 'Building name');
+		building.add(TGI.random(FileType.Exemplar), buildingExemplar);
+		building.save(path.join(plugins, 'building.SC4Desc'));
+
+		let lot = new DBPF();
+		let lotExemplar = new Exemplar();
+		lotExemplar.addProperty('ExemplarType', ExemplarProperty.ExemplarType.LotConfigurations);
+		lotExemplar.addProperty('ExemplarName', 'Lot name');
+		lotExemplar.lotObjects.push(
+			new LotObject({
+				type: LotObject.Building,
+				IID: building.entries[0]!.instance,
+			}),
+		);
+		lot.add(TGI.random(FileType.Exemplar, 0xa8fbd372), lotExemplar);
+		lot.save(path.join(plugins, 'lot.SC4Lot'));
+
+		let tracker = new DependencyTracker({
+			installation,
+			plugins,
+		});
+		let result = await tracker.track(plugins) as any;
+		let { tree } = result;
+		expect(tree).to.have.length(1);
+		expect(tree[0].kind).to.equal('lot');
+		expect(tree[0].entry.instance).to.equal(lot.entries[0].instance);
+		expect(tree[0].building.kind).to.equal('exemplar');
+		expect(tree[0].building.name).to.equal('Building name');
+		expect(tree[0].building.models).to.have.length(1);
+		expect(tree[0].building.models[0].kind).to.equal('model');
+
+	});
+
+	it('does not track props added to a Maxis family as dependencies (#77)', async function() {
+
+		let { installation, plugins } = await setup();
 		let family = randomId();
 		let coreFile = new DBPF();
 		let coreExemplar = new Exemplar();
 		coreExemplar.addProperty('ExemplarType', ExemplarProperty.ExemplarType.Prop);
 		coreExemplar.addProperty('BuildingpropFamily', [family]);
 		coreFile.add(TGI.random(FileType.Exemplar), coreExemplar);
-		coreFile.save(path.join(core, 'SimCity_1.dat'));
+		coreFile.save(path.join(installation, 'SimCity_1.dat'));
 
 		let pluginFile = new DBPF();
 		let pluginExemplar = new Exemplar();
@@ -44,7 +94,7 @@ describe('#DependencyTracker', function() {
 		lot.save(path.join(plugins, 'lot.SC4Lot'));
 
 		let tracker = new DependencyTracker({
-			installation: core,
+			installation,
 			plugins,
 		});
 		let result = await tracker.track(path.join(plugins, 'lot.SC4Lot'));
@@ -55,19 +105,14 @@ describe('#DependencyTracker', function() {
 
 	it('does not track props that override Maxis props (#77)', async function() {
 
-		let folder = output('deps');
-		await fs.promises.rm(folder, { recursive: true, force: true });
-		let core = path.join(folder, 'core');
-		let plugins = path.join(folder, 'plugins');
-		await fs.promises.mkdir(core, { recursive: true });
-		await fs.promises.mkdir(plugins, { recursive: true });
+		let { installation, plugins } = await setup();
 
 		let tgi = TGI.random(FileType.Exemplar);
 		let coreFile = new DBPF();
 		let coreExemplar = new Exemplar();
 		coreExemplar.addProperty('ExemplarType', ExemplarProperty.ExemplarType.Prop);
 		coreFile.add(tgi, coreExemplar);
-		coreFile.save(path.join(core, 'SimCity_1.dat'));
+		coreFile.save(path.join(installation, 'SimCity_1.dat'));
 
 		let pluginFile = new DBPF();
 		let pluginExemplar = new Exemplar();
@@ -86,7 +131,7 @@ describe('#DependencyTracker', function() {
 		lot.save(path.join(plugins, 'lot.SC4Lot'));
 
 		let tracker = new DependencyTracker({
-			installation: core,
+			installation: installation,
 			plugins,
 		});
 		let result = await tracker.track(path.join(plugins, 'lot.SC4Lot'));


### PR DESCRIPTION
When tracking dependencies for some of Pegasus' packages, we noticed that the QueryExemplarGUID can be the same as the IID of a building exemplar, which caused a circular dependency to be present, and hence either crashing or hanging the dependency tracking process. This fixes that by taking into account that UI files have TypeID `0x00000000`.

Additionally this PR also fixes another quirk in the dependency tracking logic. If you have both [peg:trail-parks-iii](https://community.simtropolis.com/files/file/11001-peg-trail-parks-iii/) and [peg:mtp-super-pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/), then the super pack gets tracked as a dependency because it includes textures with the same IID that are already included in the trail parks as well. The textures are the same, so it's probably on purpose, but we shouldn't report `peg:mtp-super-pack` as a dependency in this case, as it is not actually one! We solved this by always prioritizing *internal* files of a package over external dependencies in case of overrides.