### PR TITLE
fix: plugin indexing hangs in sea

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "qfs-compression": "^0.2.3",
         "semver": "^7.3.5",
         "smart-arraybuffer": "^1.0.0-alpha.2",
+        "supports-color": "^10.0.0",
         "tar": "^6.1.8",
         "uint8array-extras": "^1.4.0",
         "yaml": "^2.6.0"
@@ -4508,6 +4509,18 @@
       "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
       "integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g=="
     },
+    "node_modules/supports-color": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
+      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8487,6 +8500,11 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
       "integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g=="
+    },
+    "supports-color": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
+      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "qfs-compression": "^0.2.3",
     "semver": "^7.3.5",
     "smart-arraybuffer": "^1.0.0-alpha.2",
+    "supports-color": "^10.0.0",
     "tar": "^6.1.8",
     "uint8array-extras": "^1.4.0",
     "yaml": "^2.6.0"

--- a/src/plugins/dependency-tracker.ts
+++ b/src/plugins/dependency-tracker.ts
@@ -761,7 +761,7 @@ class DependencyTrackingResult {
 	dump({ format = 'sc4pac' }: DependencyTrackingResultDumpOptions = {}) {
 
 		// Show the installation and plugins folder.
-		const { bold, cyan, red } = chalk;
+		const { bold, cyan, red, green } = chalk;
 		console.log(bold('Installation folder:'), cyan(this.installation));
 		console.log(bold('Plugins folder:'), cyan(this.plugins));
 
@@ -791,6 +791,11 @@ class DependencyTrackingResult {
 				for (let dep of deps) {
 					console.log(`  - ${cyan(dep)}`);
 				}
+			}
+
+			// If there are no dependencies at all, make sure to log it too.
+			if (this.packages.length + deps.length === 0) {
+				console.log(green('No external dependencies'));
 			}
 
 		}

--- a/src/plugins/dependency-tracker.ts
+++ b/src/plugins/dependency-tracker.ts
@@ -794,7 +794,7 @@ class DependencyTrackingResult {
 			}
 
 			// If there are no dependencies at all, make sure to log it too.
-			if (this.packages.length + deps.length === 0) {
+			if (this.packages.length + deps.length + this.missing.length === 0) {
 				console.log(green('No external dependencies'));
 			}
 

--- a/src/threading/worker-pool.ts
+++ b/src/threading/worker-pool.ts
@@ -70,7 +70,11 @@ export default class WorkerPool extends EventEmitter {
 		this.url = url ? String(url) : undefined;
 		this.ts = ts;
 		this.script = script;
-		this.numThreads = numThreads;
+
+		// IMPORTANT! If we're running as sea, we'll *always* run in separate 
+		// threads, because in that case we have a script, which is can only be 
+		// run in a separate thread anyway.
+		this.numThreads = Math.max(numThreads, this.script ? 1 : 0);
 		this.workers = [];
 		this.freeWorkers = [];
 		this.tasks = [];


### PR DESCRIPTION
This PR fixes the plugin indexing being stuck when using the `.exe` instead of the npm module (#86). The reason was that if we decided to not use multithreading for indexing the plugins folder - which happens for a low number of plugins - then we couldn't import the thread script, which caused the process to hang.