### PR TITLE
feat: implement sc4pac-aware datpacking

### DIFF
--- a/src/cli/commands/dbpf-add-command.ts
+++ b/src/cli/commands/dbpf-add-command.ts
@@ -146,23 +146,8 @@ class AddOperation {
 		this.spinner?.update(`Adding ${file}`);
 		let dbpf = new DBPF({ file, parse: false });
 		await dbpf.parseAsync();
-		for (let entry of dbpf) {
-
-			// Skip the dir entry of course, the destination DBPF will create 
-			// its own dir entry.
-			if (entry.type === FileType.DIR) continue;
-
-			// Don't parse or decompress the entry, we'll just keep it as is: a 
-			// potentially compressed buffer read from the filesystem.
-			let buffer = await entry.readRawAsync();
-			await this.stream.add(entry.tgi, buffer, {
-				compressed: entry.compressed,
-				compressedSize: entry.compressedSize,
-				fileSize: entry.fileSize,
-			});
-			this.counter++;
-
-		}
+		await this.stream.addDbpf(dbpf);
+		this.counter += dbpf.length;
 	}
 
 }

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -15,3 +15,4 @@ export * from './dbpf-add-command.js';
 export * from './city-count-command.js';
 export * from './plugins-duplicates-command.js';
 export * from './plugins-track-command.js';
+export * from './plugins-datpack-command.js';

--- a/src/cli/commands/interactive-command.js
+++ b/src/cli/commands/interactive-command.js
@@ -104,6 +104,14 @@ async function start(n) {
 			},
 		},
 		{
+			name: 'Datpack sc4pac plugins',
+			async value() {
+				let args = await flows.datpack();
+				if (!args) return;
+				await commands.pluginsDatpack(...args);
+			},
+		},
+		{
 			name: 'Plop all lots of a collection',
 			type: 'city',
 			async value() {

--- a/src/cli/commands/plugins-datpack-command.ts
+++ b/src/cli/commands/plugins-datpack-command.ts
@@ -1,0 +1,54 @@
+import { Glob } from 'glob';
+import { styleText } from 'node:util';
+import logger from '#cli/logger.js';
+import { FileScanner, folderToPackageId } from 'sc4/plugins';
+import { DBPF, DBPFStream } from 'sc4/core';
+import path from 'node:path';
+import fs from 'node:fs';
+
+// # plugins-datpack-command.ts
+type DatPackCommandOptions = {
+	directory?: string;
+};
+
+export async function pluginsDatpack(opts: DatPackCommandOptions) {
+	const { directory = process.env.SC4_PLUGINS } = opts;
+	const glob = new Glob('[0-9][0-9][0,2,4,6,8]-*/*.sc4pac/', {
+		cwd: directory,
+		absolute: true,
+	});
+	const folders = await glob.walk();
+	logger.progress.start('Scanning plugins');
+	for (let folder of folders) {
+		let glob = new FileScanner('**/*', { cwd: folder });
+		let files = await glob.walk();
+		files.sort();
+		if (files.length > 10) {
+			let basename = path.basename(folder);
+			let output = path.join(folder, `${basename}.dat`);
+			let id = styleText('green', folderToPackageId(folder)!);
+			let stream = new DBPFStream(output, 'w');
+			for (let file of files) {
+				logger.progress.update(`Processing ${id}/${path.basename(file)}`)
+				let dbpf = new DBPF({ file, parse: false });
+				await dbpf.parseAsync();
+				await stream.addDbpf(dbpf);
+			}
+			await stream.seal();
+
+			// Remove all files, and then all folders as well - which should be empty now.
+			for (let file of files) {
+				await fs.promises.rm(file);
+			}
+			const glob = new Glob('*/', {
+				cwd: folder,
+				absolute: true,
+			});
+			for await (let folder of glob) {
+				await fs.promises.rm(folder, { recursive: true, force: true });
+			}
+
+		}
+	}
+	logger.progress.succeed();
+}

--- a/src/cli/commands/plugins-datpack-command.ts
+++ b/src/cli/commands/plugins-datpack-command.ts
@@ -5,50 +5,162 @@ import { FileScanner, folderToPackageId } from 'sc4/plugins';
 import { DBPF, DBPFStream } from 'sc4/core';
 import path from 'node:path';
 import fs from 'node:fs';
+import PQueue from 'p-queue';
 
 // # plugins-datpack-command.ts
 type DatPackCommandOptions = {
 	directory?: string;
+	limit?: number;
 };
 
 export async function pluginsDatpack(opts: DatPackCommandOptions) {
-	const { directory = process.env.SC4_PLUGINS } = opts;
-	const glob = new Glob('[0-9][0-9][0,2,4,6,8]-*/*.sc4pac/', {
-		cwd: directory,
-		absolute: true,
-	});
-	const folders = await glob.walk();
-	logger.progress.start('Scanning plugins');
-	for (let folder of folders) {
-		let glob = new FileScanner('**/*', { cwd: folder });
-		let files = await glob.walk();
-		files.sort();
-		if (files.length > 10) {
-			let basename = path.basename(folder);
-			let output = path.join(folder, `${basename}.dat`);
-			let id = styleText('green', folderToPackageId(folder)!);
-			let stream = new DBPFStream(output, 'w');
-			for (let file of files) {
-				logger.progress.update(`Processing ${id}/${path.basename(file)}`)
-				let dbpf = new DBPF({ file, parse: false });
-				await dbpf.parseAsync();
-				await stream.addDbpf(dbpf);
-			}
-			await stream.seal();
+	const {
+		directory = process.env.SC4_PLUGINS ?? process.cwd(),
+		limit,
+	} = opts;
+	const packer = new Datpacker({ limit });
+	await packer.scan(directory);
+}
 
-			// Remove all files, and then all folders as well - which should be empty now.
-			for (let file of files) {
-				await fs.promises.rm(file);
-			}
-			const glob = new Glob('*/', {
-				cwd: folder,
-				absolute: true,
-			});
-			for await (let folder of glob) {
-				await fs.promises.rm(folder, { recursive: true, force: true });
-			}
+type DatpackerOptions = {
+	limit?: number;
+};
 
-		}
+type Job = {
+	folder: string;
+	files: string[];
+};
+
+class Datpacker {
+	limit = 10;
+	logger = logger;
+	progress: {
+		total: number;
+		processed: number;
+		toString: () => string;
+	};
+
+	// ## constructor()
+	constructor(opts: DatpackerOptions = {}) {
+		const { limit = 10 } = opts;
+		this.limit = limit;
 	}
-	logger.progress.succeed();
+
+	// ## scan(directory)
+	// The entry point for starting the datpacking.
+	async scan(directory: string) {
+
+		// First of all we'll prepare all the jobs by looking for all .sc4pac 
+		// folders, and then count the amount of files in the folder.
+		const folders = new Glob('*/*.sc4pac/', {
+			cwd: directory,
+			absolute: true,
+		});
+		const queue = new PQueue({ concurrency: 256 });
+		const jobs: Job[] = [];
+		let total = 0;
+		this.logger.progress.start('Looking for folders to datpack');
+		for await (let cwd of folders) {
+			queue.add(async () => {
+				let glob = new FileScanner('**/*', { cwd });
+				let files = await glob.walk();
+				if (files.length < this.limit) return;
+				jobs.push({
+					folder: cwd,
+					files,
+				});
+				total += files.length;
+				this.logger.progress.update(
+					`Found ${jobs.length} folders to datpack (${total} files, limit: ${this.limit})`,
+				);
+			});
+		}
+		await queue.onIdle();
+
+		// Now that we have all jobs, we'll initialize our progress object.
+		if (jobs.length === 0) {
+			this.logger.progress.succeed(`No folders found to datpack (limit: ${this.limit})`);
+			return;
+		} else {
+			this.logger.progress.succeed();
+		}
+		this.progress = new Progress({ total, width: 25 });
+
+		// Now actually perform the datpacking. Note: we'll sort the jobs so 
+		// that the jobs with the most files get executed *first*. That way we 
+		// make sure that we maximize parallelization by avoiding that the long 
+		// running jobs are only started in the end.
+		jobs.sort((a, b) => b.files.length - a.files.length);
+		this.logger.progress.start(this.progress.toString());
+		for (let job of jobs) {
+			queue.add(() => this.execute(job));
+		}
+		await queue.onIdle();
+		this.logger.progress.succeed('Datpacking completed');
+	}
+
+	// ## execute(job)
+	// The function that will actually datpack the folder, provided that the 
+	// amount of files is above the threshold.
+	async execute(job: Job) {
+
+		// Use the file scanner to find all files to be added, which will also 
+		// count the files as a bonus.
+		const { folder, files } = job;
+
+		// Make sure the files are sorted so that they will be added in the 
+		// correct order to the DBPF.
+		files.sort();
+		let basename = path.basename(folder);
+		let output = path.join(folder, `${basename}.dat`);
+		let id = styleText('green', folderToPackageId(folder)!);
+		let stream = new DBPFStream(output, 'w');
+		for (let file of files) {
+			let bar = this.progress.toString();
+			logger.progress.update(`${bar} Processing ${id}/${path.basename(file)}`)
+			let dbpf = new DBPF({ file, parse: false });
+			await dbpf.parseAsync();
+			await stream.addDbpf(dbpf);
+			this.progress.processed++;
+		}
+		await stream.seal();
+
+		// Remove all files, and then all folders as well - which should be 
+		// empty now.
+		for (let file of files) {
+			await fs.promises.rm(file);
+		}
+		let deletions = new Glob('*/', {
+			cwd: folder,
+			absolute: true,
+		});
+		for await (let folder of deletions) {
+			await fs.promises.rm(folder, { recursive: true, force: true });
+		}
+
+	}
+
+}
+
+type ProgressOptions = {
+	total?: number;
+	width?: number;
+};
+
+class Progress {
+	total = 1;
+	processed = 0;
+	width = 25;
+	constructor(opts: ProgressOptions) {
+		this.total = opts.total ?? 1;
+		this.width = opts.width ?? 25;
+	}
+	toString() {
+		const { total, processed, width } = this;
+		const fraction = processed/total;
+		const bar = '='.repeat(Math.round(fraction*width));
+		const rest = ' '.repeat(width-bar.length);
+		const pct = Math.round(fraction*100);
+		return `[${bar}${rest}] ${pct}%`;
+	}
 }

--- a/src/cli/commands/plugins-datpack-command.ts
+++ b/src/cli/commands/plugins-datpack-command.ts
@@ -13,13 +13,11 @@ type DatPackCommandOptions = {
 	limit?: number;
 };
 
-export async function pluginsDatpack(opts: DatPackCommandOptions) {
-	const {
-		directory = process.env.SC4_PLUGINS ?? process.cwd(),
-		limit,
-	} = opts;
+export async function pluginsDatpack(directory?: string, opts: DatPackCommandOptions = {}) {
+	const { limit } = opts;
+	const plugins = path.resolve(process.cwd(), directory ?? process.env.SC4_PLUGINS ?? '.');
 	const packer = new Datpacker({ limit });
-	await packer.scan(directory);
+	await packer.scan(plugins);
 }
 
 type DatpackerOptions = {
@@ -43,7 +41,7 @@ class Datpacker {
 	// ## constructor()
 	constructor(opts: DatpackerOptions = {}) {
 		const { limit = 10 } = opts;
-		this.limit = limit;
+		this.limit = Math.max(2, limit);
 	}
 
 	// ## scan(directory)

--- a/src/cli/flows/datpack-flow.ts
+++ b/src/cli/flows/datpack-flow.ts
@@ -1,0 +1,37 @@
+// # datpack-flow.ts
+import * as prompts from '#cli/prompts';
+import chalk from 'chalk';
+
+export async function datpack() {
+
+	let confirm = await prompts.confirm({
+		message: `This action intentionally only datpacks plugins installed with sc4pac, but it will modify your plugins folder in place. If your plugins become corrupted, you can restore them by deleting the ${chalk.cyan('sc4pac-plugins-lock.json')} lockfile and then run sc4pac update again. Are you sure you want to continue?`,
+		default: false,
+		theme: {
+			prefix: chalk.red('WARNING'),
+		},
+	});
+	if (!confirm) return;
+
+	let directory = process.env.SC4_PLUGINS as string;
+	let useFolder = await prompts.confirm({
+		message: `Is this the plugins folder to datpack? ${chalk.cyan(directory)}`,
+		default: true,
+	});
+	if (!useFolder) {
+		directory = await prompts.fileSelector({
+			message: 'Select the folder to datpack',
+			basePath: process.cwd(),
+			type: 'directory',
+			filter: info => info.isDirectory(),
+		});
+	}
+
+	// Ask for the limit.
+	let limit = await prompts.number({
+		message: 'What is the minimum amount of files a plugin should contain before being datpacked?',
+		default: 10,
+	});
+	return [directory, { limit }];
+
+}

--- a/src/cli/flows/index.js
+++ b/src/cli/flows/index.js
@@ -7,3 +7,4 @@ export * from './scan-for-menus-flow.js';
 export * from './change-icon-flow.js';
 export * from './plop-all-flow.js';
 export * from './plugins-track-flow.js';
+export * from './datpack-flow.js';

--- a/src/cli/prompts/file-selector-prompt.ts
+++ b/src/cli/prompts/file-selector-prompt.ts
@@ -125,10 +125,10 @@ export type FileSelectorConfig = {
 	emptyText?: string;
 	theme?: Theme;
 	filter?: (file: FileInfo) => boolean;
-	transform: (item: FileInfo) => string;
+	transform?: (item: FileInfo) => string;
 };
 
-export const fileSelector = createPrompt((config: FileSelectorConfig, done: any) => {
+export const fileSelector = createPrompt<string, FileSelectorConfig>((config: FileSelectorConfig, done: any) => {
 	const {
 		type = 'file',
 		pageSize = 10,

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -181,7 +181,7 @@ export function factory(program) {
 	plugins
 		.command('datpack')
 		.description('Optimizes your plugins folder by datpacking every sc4pac package')
-		.option('-d, --directory <dir>', 'The plugins folder to datpack. Defaults to your configured plugins folder')
+		.argument('[dir]', 'The plugins folder to datpack. Defaults to your configured plugins folder')
 		.option('--limit <limit>', 'The minimum amount of files required in a folder before datpacking will be performed. Defaults to 10', parsers.number)
 		.action(commands.pluginsDatpack);
 

--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -177,6 +177,14 @@ export function factory(program) {
 		.option('-d, --directory <dir>', 'The directory to look for duplicates in. Defaults to your configured plugins folder')
 		.action(commands.pluginsDuplicates);
 
+	// Command for sc4pac-aware datpacking of a users plugins folder.
+	plugins
+		.command('datpack')
+		.description('Optimizes your plugins folder by datpacking every sc4pac package')
+		.option('-d, --directory <dir>', 'The plugins folder to datpack. Defaults to your configured plugins folder')
+		.option('--limit <limit>', 'The minimum amount of files required in a folder before datpacking will be performed. Defaults to 10', parsers.number)
+		.action(commands.pluginsDatpack);
+
 	// Commands that operate specifically on dbpfs, such as extracting a DBPF.
 	const dbpf = program
 		.command('dbpf')


### PR DESCRIPTION
This PR adds sc4pac-aware datpacking both as an interactive action, or as a separate command `sc4 plugins datpack`. It will scan your configured plugins folder and will create a single `.dat` from all files in the folder in case the amount of files in that folder is higher than a configurable amount (which defaults to 10).

> [!CAUTION]
> The datpacking happens in place, so it **WILL** modify your plugins folder by deleting all files and replacing them with a `.dat`. However, this only happens inside folders that were installed with sc4pac - more specifically, folders that end with `.sc4pac`. This means that if something goes wrong, you can restore your plugins by deleting the `sc4pac-plugins-lock.json` file and then running `sc4pac update` again.

Related: https://github.com/sebamarynissen/simtropolis-channel/pull/52

@memo33: do you think it would be useful to add some kind of `restore` or `clean-install` option to the sc4pac cli and gui? This would simply reinstall every dependency again, regardless of which ones are already installed, which could be handy in case the datpacking has gone wrong.