### PR TITLE
refactor: refactor how missing dependencies are reported

### DIFF
--- a/src/plugins/dependency-tracker.ts
+++ b/src/plugins/dependency-tracker.ts
@@ -605,6 +605,7 @@ class DependencyTrackingContext {
 		// ItemIcon, ...
 		const props = {
 			UserVisibleNameKey: { type: FileType.LTEXT },
+			ItemDescriptionKey: { type: FileType.LTEXT },
 			ItemIcon: { type: FileType.PNG, group: 0x6a386d26 },
 			QueryExemplarGUID: { type: 0x00000000 },
 			SFXQuerySound: { type: 0x0b8d821a },

--- a/src/plugins/dependency-tracker.ts
+++ b/src/plugins/dependency-tracker.ts
@@ -494,11 +494,6 @@ class DependencyTrackingContext {
 		// as a missing dependency.
 		if (!entry) {
 			let kind = Object.keys(LotObjectType)[lotObject.type];
-			this.missing.push({
-				kind,
-				file: lotEntry.dbpf.file,
-				instance: iid,
-			});
 			return this.addMissing({
 				resource: kind,
 				instance: iid,

--- a/src/plugins/dependency-types.ts
+++ b/src/plugins/dependency-types.ts
@@ -414,12 +414,27 @@ export class Raw extends Dependency {
 	}
 }
 
+export type MissingOptions = {
+	type?: number;
+	group?: number;
+	instance: number;
+	resource: string;
+	parent: Entry;
+};
+
 // # Missing
 // Represents a mising dependency
 export class Missing extends Dependency {
 	kind = 'missing';
-	constructor(entry: EntryLike) {
-		super({ entry });
+	resource: string;
+	parent: Entry;
+	constructor(opts: MissingOptions) {
+		let { type, group, instance, resource, parent } = opts;
+		super({
+			entry: { type, group, instance },
+		});
+		this.resource = resource;
+		this.parent = parent;
 	}
 	toLines({ width = DEFAULT_WIDTH, level = 0 }: ToLinesOptions = {}) {
 		const { type, group, instance } = this.entry;


### PR DESCRIPTION
This PR changes the way missing dependencies are collected in the dependency tracker. We've also slightly modified the output format for missing dependencies so that duplicate missing dependencies are not listed twice. Instead we show what tgi's they are referenced by.

On top of that, the dependency tracking script now also reports missing dependencies such as `QueryExemplarGUID` in the sc4pac format - which is the default.