### PR TITLE
fix: use proper load order

### DIFF
--- a/src/cli/commands/plugins-datpack-command.ts
+++ b/src/cli/commands/plugins-datpack-command.ts
@@ -6,6 +6,7 @@ import { DBPF, DBPFStream } from 'sc4/core';
 import path from 'node:path';
 import fs from 'node:fs';
 import PQueue from 'p-queue';
+import createComparator from 'src/plugins/compare-load-order.js';
 
 // # plugins-datpack-command.ts
 type DatPackCommandOptions = {
@@ -63,6 +64,8 @@ class Datpacker {
 				let glob = new FileScanner('**/*', { cwd });
 				let files = await glob.walk();
 				if (files.length < this.limit) return;
+				const compare = createComparator();
+				files.sort((a, b) => -compare(a, b));
 				jobs.push({
 					folder: cwd,
 					files,

--- a/src/cli/commands/plugins-datpack-command.ts
+++ b/src/cli/commands/plugins-datpack-command.ts
@@ -1,12 +1,15 @@
 import { Glob } from 'glob';
 import { styleText } from 'node:util';
 import logger from '#cli/logger.js';
-import { FileScanner, folderToPackageId } from 'sc4/plugins';
+import {
+	FileScanner,
+	folderToPackageId,
+	createLoadComparator as createComparator,
+} from 'sc4/plugins';
 import { DBPF, DBPFStream } from 'sc4/core';
 import path from 'node:path';
 import fs from 'node:fs';
 import PQueue from 'p-queue';
-import createComparator from 'src/plugins/compare-load-order.js';
 
 // # plugins-datpack-command.ts
 type DatPackCommandOptions = {

--- a/src/plugins/compare-load-order.ts
+++ b/src/plugins/compare-load-order.ts
@@ -1,0 +1,38 @@
+// # sort-load-order.js
+// # createComparator()
+export default function createComparator() {
+	const table = new HashTable();
+	return function compare(a: string, b: string): number {
+		let ha = table.getHash(a);
+		let hb = table.getHash(b);
+		let min = Math.min(ha.length, hb.length)-1;
+		let i = 0;
+		for (; i < min; i++) {
+			let a = ha[i];
+			let b = hb[i];
+			if (a === b) continue;
+			return a < b ? -1 : 1;
+		}
+		
+		// If we haven't made a decision by now, it means either both files are 
+		// in the same folder, or one folder is a subfolder of the other one.
+		if (ha.length === hb.length) {
+			let da = ha[i].endsWith('.DAT') ? 1 : -1;
+			let db = hb[i].endsWith('.DAT') ? 1 : -1;
+			return da-db || ha[i] < hb[i] ? -1 : 1;
+		} else {
+			return ha.length < hb.length ? -1 : 1;
+		}
+
+	};
+}
+
+class HashTable {
+	table: Record<string, string[]> = Object.create(null);
+	getHash(file: string) {
+		let arr = this.table[file];
+		if (arr) return arr;
+		let parts = file.toUpperCase().split(/[\/\\]/);
+		return arr = this.table[file] = parts;
+	}
+}

--- a/src/plugins/create-load-comparator.ts
+++ b/src/plugins/create-load-comparator.ts
@@ -1,6 +1,6 @@
 // # sort-load-order.js
-// # createComparator()
-export default function createComparator() {
+// # createLoadComparator()
+export default function createLoadComparator() {
 	const table = new HashTable();
 	return function compare(a: string, b: string): number {
 		let ha = table.getHash(a);

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -6,3 +6,4 @@ export { default as folderToPackageId } from './folder-to-package-id.js';
 export { default as createSubmenuPatch } from './create-submenu-patch.js';
 export { default as createSubmenuButton } from './create-submenu-button.js';
 export { default as unpackSubmenu } from './unpack-submenu.js';
+export { default as createLoadComparator } from './create-load-comparator.js';

--- a/src/plugins/plugin-index.ts
+++ b/src/plugins/plugin-index.ts
@@ -17,6 +17,7 @@ import type {
 } from 'sc4/core';
 import type { TGIArray, TGIQuery, uint32 } from 'sc4/types';
 import type { TGIFindParameters, TGIIndexJSON } from 'sc4/utils';
+import createComparator from './compare-load-order.js';
 const Family = ExemplarProperty.BuildingpropFamily;
 const debug = debugModule('sc4:plugins:index');
 debugModule.formatters.h = (array: number | number[]) => {
@@ -497,9 +498,7 @@ export default class PluginIndex {
 
 // # compare(a, b)
 // The comparator function that determines the load order of the files.
-function compare(a: string, b: string) {
-	return a.toLowerCase() < b.toLowerCase() ? -1 : 1;
-}
+const compare = createComparator();
 
 // # hash(tgi)
 function hash(tgi: TGI) {

--- a/src/plugins/plugin-index.ts
+++ b/src/plugins/plugin-index.ts
@@ -170,8 +170,8 @@ export default class PluginIndex {
 
 		// Sort both the core files and the plugins, but do it separately so 
 		// that the plugins *always* override the core files.
-		coreFiles.sort(compare);
-		sourceFiles.sort(compare);
+		coreFiles.sort(createComparator());
+		sourceFiles.sort(createComparator());
 		return [...coreFiles, ...sourceFiles];
 
 	}
@@ -495,10 +495,6 @@ export default class PluginIndex {
 	}
 
 }
-
-// # compare(a, b)
-// The comparator function that determines the load order of the files.
-const compare = createComparator();
 
 // # hash(tgi)
 function hash(tgi: TGI) {

--- a/src/plugins/plugin-index.ts
+++ b/src/plugins/plugin-index.ts
@@ -17,7 +17,7 @@ import type {
 } from 'sc4/core';
 import type { TGIArray, TGIQuery, uint32 } from 'sc4/types';
 import type { TGIFindParameters, TGIIndexJSON } from 'sc4/utils';
-import createComparator from './compare-load-order.js';
+import createLoadComparator from './create-load-comparator.js';
 const Family = ExemplarProperty.BuildingpropFamily;
 const debug = debugModule('sc4:plugins:index');
 debugModule.formatters.h = (array: number | number[]) => {
@@ -170,8 +170,8 @@ export default class PluginIndex {
 
 		// Sort both the core files and the plugins, but do it separately so 
 		// that the plugins *always* override the core files.
-		coreFiles.sort(createComparator());
-		sourceFiles.sort(createComparator());
+		coreFiles.sort(createLoadComparator());
+		sourceFiles.sort(createLoadComparator());
 		return [...coreFiles, ...sourceFiles];
 
 	}

--- a/src/plugins/test/compare-load-order-test.ts
+++ b/src/plugins/test/compare-load-order-test.ts
@@ -1,0 +1,80 @@
+// # compare-load-order-test.ts
+import { expect } from 'chai';
+import createComparator from '../compare-load-order.js';
+
+describe('#createComparator()', function() {
+
+	it('loads .SC4Lot, then .dat', function() {
+
+		const compare = createComparator();
+		const files = [
+			'a.dat',
+			'b.SC4Lot',
+		];
+		files.sort(compare);
+		expect(files).to.eql(['b.SC4Lot', 'a.dat']);
+
+	});
+
+	it('loads files, then folders', function() {
+
+		const compare = createComparator();
+		const files = [
+			'a/foo.dat',
+			'b.dat',
+		];
+		files.sort(compare);
+		expect(files).to.eql(['b.dat', 'a/foo.dat']);
+
+	});
+
+	it('uses uppercases names', function() {
+
+		const compare = createComparator();
+		const files = [
+			'Z.dat',
+			'a.dat',
+		];
+		files.sort(compare);
+		expect(files).to.eql(['a.dat', 'Z.dat']);
+
+	});
+
+	it('loads nested files first', function() {
+
+		const compare = createComparator();
+		const files = [
+			'B/nested/file.dat',
+			'B/file.SC4Lot',
+			'a/nested/file.dat',
+			'a/file.dat',
+		];
+		files.sort(compare);
+		expect(files).to.eql([
+			'a/file.dat',
+			'a/nested/file.dat',
+			'B/file.SC4Lot',
+			'B/nested/file.dat',
+		]);
+
+	});
+
+	it('all together now', function() {
+
+		const files = [
+			'z.SC4Lot',
+			'k.dat',
+			'L.dat',
+			'a/file.dat',
+			'a/subfolder/file.dat',
+			'B/zz_file.dat',
+			'B/subfolder/file.dat',
+			'B/subfolder/deeper/file.dat',
+		];
+		const reverse = files.toReversed();
+		reverse.sort(createComparator());
+		expect(reverse).to.eql(files);
+
+	});
+
+});

--- a/src/plugins/test/compare-load-order-test.ts
+++ b/src/plugins/test/compare-load-order-test.ts
@@ -1,8 +1,8 @@
 // # compare-load-order-test.ts
 import { expect } from 'chai';
-import createComparator from '../compare-load-order.js';
+import createComparator from '../create-load-comparator.js';
 
-describe('#createComparator()', function() {
+describe('#createLoadComparator()', function() {
 
 	it('loads .SC4Lot, then .dat', function() {
 


### PR DESCRIPTION
This PR implements a sort function that mimicks the load order that the game actually uses. We now use this both for indexing plugins - which is relevant when tracking dependencies - as well as for load-order compatible datpacking (where the order needs to be *reversed* though).

Related: #89.