### PR TITLE
feat: add optional menu-icon to icon template

### DIFF
--- a/src/cli/assets/index.html
+++ b/src/cli/assets/index.html
@@ -52,15 +52,11 @@
 		button, input[type="file"] {
 			font-size: inherit;
 		}
-		button.save {
-			padding-left: 4px;
-			padding-right: 4px;
-		}
-		button.save svg {
+		.size-3 {
 			width: 12px;
 			height: 12px;
 		}
-		form:has(input[type="file"]:invalid) button.save {
+		form:has(input[type="file"]:invalid) button {
 			visibility: hidden;
 		}
 		div.cta {
@@ -76,6 +72,8 @@
 		}
 		.flex { display: flex; }
 		.ml-2 { margin-left: 0.5rem; }
+		.leading-6 { line-height: 1.5rem; }
+		.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
 	</style>
 	<script type="module" src="./script.js"></script>
 </head>
@@ -86,13 +84,13 @@
 		<div>
 			<input type="file" name="icon" accept="image/png, image/jpeg" required>
 		</div>
-		<div>
+		<div class="leading-6 flex">
 			<label>
 				<input type="checkbox" name="templated">
 				Apply icon template
 			</label>
 		</div>
-		<div class="flex">
+		<div class="leading-6 flex">
 			<label>
 				<input type="checkbox" name="with-icon">
 				Add menu icon
@@ -105,11 +103,17 @@
 			Select an image to be used as icon. You can also drag & drop a file, or paste a url or raw image.
 		</p>
 		<div class="cta">
-			<button id="choose" class="save">
-				<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+			<button id="choose" class="px-2">
+				<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3">
  					<path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
 				</svg>
 				Use as icon
+			</button>
+			<button id="download" type="button" class="ml-2 px-2">
+				<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3">
+					<path stroke-linecap="round" stroke-linejoin="round" d="m9 13.5 3 3m0 0 3-3m-3 3v-6m1.06-4.19-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+				</svg>
+				Save as .png
 			</button>
 		</div>
 	</form>

--- a/src/cli/assets/index.html
+++ b/src/cli/assets/index.html
@@ -37,6 +37,8 @@
 		canvas {
 			margin-top: 12px;
 			margin-bottom: 12px;
+			width: 176px;
+			height: 44px;
 		}
 		input[type="file"] {
 			margin-bottom: 12px;
@@ -86,6 +88,12 @@
 			<label>
 				<input type="checkbox" name="templated">
 				Apply icon template
+			</label>
+		</div>
+		<div>
+			<label>
+				<input type="checkbox" name="with-icon">
+				Add menu icon
 			</label>
 		</div>
 		<p>

--- a/src/cli/assets/index.html
+++ b/src/cli/assets/index.html
@@ -74,6 +74,8 @@
 		label > input {
 			margin-right: 0.5rem;
 		}
+		.flex { display: flex; }
+		.ml-2 { margin-left: 0.5rem; }
 	</style>
 	<script type="module" src="./script.js"></script>
 </head>
@@ -90,11 +92,14 @@
 				Apply icon template
 			</label>
 		</div>
-		<div>
+		<div class="flex">
 			<label>
 				<input type="checkbox" name="with-icon">
 				Add menu icon
 			</label>
+			<div class="ml-2">
+				<input type="color" name="icon-color" value="#ffffff">
+			</div>
 		</div>
 		<p>
 			Select an image to be used as icon. You can also drag & drop a file, or paste a url or raw image.

--- a/src/cli/assets/script.js
+++ b/src/cli/assets/script.js
@@ -63,18 +63,21 @@ async function draw(canvas, img, overlay, templated) {
 		ctx.clip(region);
 		ctx.drawImage(img, ...offsets, x, 0, 44, 44);
 
-		let w = 6;
-		let dx = 7;
-		let dy = 7;
-		ctx.save();
-		ctx.strokeStyle = 'white';
-		ctx.strokeWidth = '1px';
-		for (let i = 0; i < 3; i++) {
-			ctx.moveTo(x+dx, dy+2*i-0.5);
-			ctx.lineTo(x+dx+w, dy+2*i-0.5);
-			ctx.stroke();
+		// Apply the menu icon if specified.
+		if (withIcon) {
+			let w = 6;
+			let dx = 7;
+			let dy = 7;
+			ctx.save();
+			ctx.strokeStyle = 'white';
+			ctx.strokeWidth = '1px';
+			for (let i = 0; i < 3; i++) {
+				ctx.moveTo(x+dx, dy+2*i-0.5);
+				ctx.lineTo(x+dx+w, dy+2*i-0.5);
+				ctx.stroke();
+			}
+			ctx.restore();
 		}
-		ctx.restore();
 
 		if (i === 0) {
 			applyGrayscale(ctx);
@@ -152,6 +155,7 @@ let sourceImage = null;
 let overlayImage = null;
 let message = '';
 let templated = true;
+let withIcon = false;
 
 // # setFile(file)
 async function setFile(file) {
@@ -184,6 +188,7 @@ function set() {
 // function, except that we now have to call it manually.
 const input = document.querySelector('input[type="file"]');
 const $templated = document.querySelector('input[name="templated"]');
+const $withIcon = document.querySelector('input[name="with-icon"]');
 const canvas = document.querySelector('canvas');
 const form = document.querySelector('form');
 const h1 = document.querySelector('h1');
@@ -197,11 +202,12 @@ function render() {
 		} else {
 			clear(canvas);
 		}
-	}, [sourceImage, overlayImage, templated]);
+	}, [sourceImage, overlayImage, templated, withIcon]);
 
 	// Update the heading text.
 	h1.textContent = message;
 	$templated.checked = templated;
+	$withIcon.disabled = !templated;
 
 }
 
@@ -266,6 +272,9 @@ window.addEventListener('paste', e => {
 // Listen to the raw being checked or not.
 $templated.addEventListener('input', event => {
 	set(templated = event.target.checked);
+});
+$withIcon.addEventListener('input', event => {
+	set(withIcon = event.target.checked);
 });
 
 // Get the configuration data.

--- a/src/cli/assets/script.js
+++ b/src/cli/assets/script.js
@@ -62,10 +62,25 @@ async function draw(canvas, img, overlay, templated) {
 		region.roundRect(x, 0, 44, 44, 7);
 		ctx.clip(region);
 		ctx.drawImage(img, ...offsets, x, 0, 44, 44);
+
+		let w = 6;
+		let dx = 7;
+		let dy = 7;
+		ctx.save();
+		ctx.strokeStyle = 'white';
+		ctx.strokeWidth = '1px';
+		for (let i = 0; i < 3; i++) {
+			ctx.moveTo(x+dx, dy+2*i-0.5);
+			ctx.lineTo(x+dx+w, dy+2*i-0.5);
+			ctx.stroke();
+		}
+		ctx.restore();
+
 		if (i === 0) {
 			applyGrayscale(ctx);
 		}
 		ctx.restore();
+
 	}
 
 	// At last draw the overlay.

--- a/src/cli/assets/script.js
+++ b/src/cli/assets/script.js
@@ -42,26 +42,26 @@ function clear(canvas) {
 // default we apply the icon template to it - meaning drawing the image four 
 // times and applying the grayscale, but you can also choose to just rawdog it 
 // onto the canvas - useful for existing icons!
-async function draw(canvas, img, overlay, templated) {
+async function draw(canvas, { image, overlay, templated }) {
 
 	// Rawdog if possible.
 	const ctx = canvas.getContext('2d');
 	clear(canvas);
 	if (!templated) {
-		ctx.drawImage(img, 0, 0);
+		ctx.drawImage(image, 0, 0);
 		return;
 	}
 
 	// Draw the image four times. Note that the first time we have to apply the 
 	// grayscaling.
-	const offsets = getSourceOffset(img);
+	const offsets = getSourceOffset(image);
 	for (let i = 0; i < 4; i++) {
 		let x = 44*i;
 		ctx.save();
 		let region = new Path2D();
 		region.roundRect(x, 0, 44, 44, 7);
 		ctx.clip(region);
-		ctx.drawImage(img, ...offsets, x, 0, 44, 44);
+		ctx.drawImage(image, ...offsets, x, 0, 44, 44);
 
 		// Apply the menu icon if specified.
 		if (withIcon) {
@@ -69,7 +69,7 @@ async function draw(canvas, img, overlay, templated) {
 			let dx = 7;
 			let dy = 7;
 			ctx.save();
-			ctx.strokeStyle = 'white';
+			ctx.strokeStyle = color;
 			ctx.strokeWidth = '1px';
 			for (let i = 0; i < 3; i++) {
 				ctx.moveTo(x+dx, dy+2*i-0.5);
@@ -156,6 +156,7 @@ let overlayImage = null;
 let message = '';
 let templated = true;
 let withIcon = false;
+let color = '#ffffff';
 
 // # setFile(file)
 async function setFile(file) {
@@ -189,6 +190,7 @@ function set() {
 const input = document.querySelector('input[type="file"]');
 const $templated = document.querySelector('input[name="templated"]');
 const $withIcon = document.querySelector('input[name="with-icon"]');
+const $color = document.querySelector('input[type="color"]');
 const canvas = document.querySelector('canvas');
 const form = document.querySelector('form');
 const h1 = document.querySelector('h1');
@@ -198,11 +200,16 @@ function render() {
 	// source image did not change, we don't constantly rerender.
 	useMemo(() => {
 		if (sourceImage && overlayImage) {
-			draw(canvas, sourceImage, overlayImage, templated);
+			draw(canvas, {
+				image: sourceImage,
+				overlay: overlayImage,
+				templated,
+				color,
+			});
 		} else {
 			clear(canvas);
 		}
-	}, [sourceImage, overlayImage, templated, withIcon]);
+	}, [sourceImage, overlayImage, templated, withIcon, color]);
 
 	// Update the heading text.
 	h1.textContent = message;
@@ -275,6 +282,9 @@ $templated.addEventListener('input', event => {
 });
 $withIcon.addEventListener('input', event => {
 	set(withIcon = event.target.checked);
+});
+$color.addEventListener('input', event => {
+	set(color = event.target.value);
 });
 
 // Get the configuration data.

--- a/src/cli/assets/script.js
+++ b/src/cli/assets/script.js
@@ -42,13 +42,18 @@ function clear(canvas) {
 // default we apply the icon template to it - meaning drawing the image four 
 // times and applying the grayscale, but you can also choose to just rawdog it 
 // onto the canvas - useful for existing icons!
-async function draw(canvas, { image, overlay, templated }) {
+async function draw(canvas, { image, overlay, templated, withIcon, color }) {
 
 	// Rawdog if possible.
 	const ctx = canvas.getContext('2d');
 	clear(canvas);
 	if (!templated) {
 		ctx.drawImage(image, 0, 0);
+		if (withIcon) {
+			for (let i = 0; i < 4; i++) {
+				drawMenuIcon(ctx, 44*i, color);
+			}
+		}
 		return;
 	}
 
@@ -65,18 +70,7 @@ async function draw(canvas, { image, overlay, templated }) {
 
 		// Apply the menu icon if specified.
 		if (withIcon) {
-			let w = 6;
-			let dx = 7;
-			let dy = 7;
-			ctx.save();
-			ctx.strokeStyle = color;
-			ctx.strokeWidth = '1px';
-			for (let i = 0; i < 3; i++) {
-				ctx.moveTo(x+dx, dy+2*i-0.5);
-				ctx.lineTo(x+dx+w, dy+2*i-0.5);
-				ctx.stroke();
-			}
-			ctx.restore();
+			drawMenuIcon(ctx, x, color);
 		}
 
 		if (i === 0) {
@@ -89,6 +83,21 @@ async function draw(canvas, { image, overlay, templated }) {
 	// At last draw the overlay.
 	ctx.drawImage(overlay, 0, 0, 176, 44);
 
+}
+
+function drawMenuIcon(ctx, x, color) {
+	let w = 6;
+	let dx = 6;
+	let dy = 7;
+	ctx.save();
+	ctx.strokeStyle = color;
+	ctx.strokeWidth = '1px';
+	for (let i = 0; i < 3; i++) {
+		ctx.moveTo(x+dx, dy+2*i-0.5);
+		ctx.lineTo(x+dx+w, dy+2*i-0.5);
+		ctx.stroke();
+	}
+	ctx.restore();
 }
 
 // # openIcon(file)
@@ -205,6 +214,7 @@ function render() {
 				overlay: overlayImage,
 				templated,
 				color,
+				withIcon,
 			});
 		} else {
 			clear(canvas);
@@ -214,8 +224,6 @@ function render() {
 	// Update the heading text.
 	h1.textContent = message;
 	$templated.checked = templated;
-	$withIcon.disabled = !templated;
-	$color.style.display = !templated || !withIcon ? 'none' : 'block';
 
 }
 

--- a/src/cli/assets/script.js
+++ b/src/cli/assets/script.js
@@ -215,6 +215,7 @@ function render() {
 	h1.textContent = message;
 	$templated.checked = templated;
 	$withIcon.disabled = !templated;
+	$color.style.display = !templated || !withIcon ? 'none' : 'block';
 
 }
 
@@ -239,6 +240,18 @@ form.addEventListener('submit', async event => {
 	});
 	window.close();
 });
+
+document.querySelector('button#download')
+	.addEventListener('click', async event => {
+		event.preventDefault();
+		let buffer = await toBuffer(canvas);
+		let blob = new Blob([buffer], { type: 'image/png' });
+		let url = URL.createObjectURL(blob);
+		let a = document.createElement('a');
+		a.href = url;
+		a.download = 'icon.png';
+		a.click();
+	});
 
 // Setup the drag/drop behavior.
 const dropArea = document.body;

--- a/src/cli/flows/new-submenu-flow.js
+++ b/src/cli/flows/new-submenu-flow.js
@@ -25,7 +25,7 @@ export async function newSubmenu() {
 		message: 'Select the icon to be used for the button:',
 	});
 	let order = +await prompts.uint32({
-		message: 'Enter the item order:',
+		message: 'Enter the item order: (number between -2,147,483,648 and 2,147,483,647):',
 		default: 0,
 	});
 	return [icon, { name, description, parent, order }];

--- a/src/cli/prompts/menu-icon-prompt.js
+++ b/src/cli/prompts/menu-icon-prompt.js
@@ -22,6 +22,7 @@ export const menuIcon = createPrompt((config, done) => {
 	const theme = makeTheme(config.theme);
 	const [url, setUrl] = useState('');
 	const [status, setStatus] = useState('idle');
+	const [address, setAddress] = useState('');
 	const prefix = usePrefix({ status, theme });
 	useMemo(() => {
 		const { default: file, ...rest } = config;
@@ -29,14 +30,17 @@ export const menuIcon = createPrompt((config, done) => {
 			...file && { default: defaultToUrl(file) },
 			...rest,
 		});
-		server.promises.listening().then(url => setUrl(url));
+		server.promises.listening().then(url => {
+			setUrl(url);
+			setAddress(theme.style.help(`(Visit ${url} if the browser doesn't open)`));
+		});
 		server.promises.ready().then(buffer => {
 			done(buffer);
 			setStatus('done');
 		});
 		return server;
 	}, []);
-	return url ? `${prefix} ${message} ${status === 'done' ? theme.style.answer('<icon>') : ''}` : '';
+	return url ? `${prefix} ${message} ${status === 'done' ? theme.style.answer('<icon>') : address }` : '';
 });
 
 // # defaultToUrl(file)


### PR DESCRIPTION
This PR adds the option to add a hamburger menu icon when creating submenus. By default the hamburger is white, but you can also change its color to anything you like.

![image](https://github.com/user-attachments/assets/28a034d2-dd9f-41b5-9c90-17de2a6851d9)

Additionally, we've also added the option to easily save the icon as a png.