### PR TITLE
feat: add support for flora submenus

### DIFF
--- a/src/cli/flows/submenu-flow.js
+++ b/src/cli/flows/submenu-flow.js
@@ -1,6 +1,5 @@
 // # submenu.js
 import path from 'node:path';
-import fs from 'node:fs';
 import * as prompts from '#cli/prompts';
 
 // # submenu()
@@ -10,31 +9,18 @@ export async function submenu() {
 
 	// If the exe was called with a bunch of files, we're going to use those 
 	// files.
-	let files = await prompts.files({
+	let directory = await prompts.files({
 		argv: true,
+		multi: false,
 		basePath: process.cwd(),
-		message: 'Select the file or directory to scan',
-		type: 'file+directory',
+		message: 'Select the directory to scan',
+		type: 'directory',
 		validate(info) {
 			if (info.isDirectory()) return true;
 			let ext = path.extname(info.path);
 			return /^\.(dat|sc4.*)$/.test(ext);
 		},
 	});
-
-	// Check if any of the files specified is a directory. If this is the case, 
-	// we'll ask whether to recursively scan the directories or not.
-	let hasDirectory = files.some(file => {
-		let info = fs.statSync(file);
-		return info.isDirectory();
-	});
-	let recursive = false;
-	if (hasDirectory) {
-		recursive = await prompts.confirm({
-			message: 'Do you want to recursively scan the folders?',
-			default: false,
-		});
-	}
 
 	// Now ask what menu the items need to be added to.
 	let menu = await prompts.menu({
@@ -44,23 +30,15 @@ export async function submenu() {
 	// Ask where to save the patch. This is a bit difficult because we need to 
 	// figure out the base directory based on the files. We'll just pick the 
 	// first one.
-	let outputDir;
-	let [first] = files;
-	let info = fs.statSync(first);
-	if (info.isDirectory()) {
-		outputDir = first;
-	} else {
-		outputDir = path.dirname(first);
-	}
 	let output = await prompts.input({
-		message: `Where do you want to save the patch (relative to ${outputDir})?`,
+		message: `Where do you want to save the patch (relative to ${directory})?`,
 		default: './submenu_patch.dat',
 	});
-	output = path.resolve(outputDir, output);
-	return [files, {
+	output = path.resolve(directory, output);
+	return [[directory], {
 		menu: +menu,
 		output,
-		recursive,
+		recursive: true,
 	}];
 
 }


### PR DESCRIPTION
This PR adds support for adding flora items to a submenu. Until now, it was only possible to add ploppable lots to a submenu. With this PR, submenus can be created for flora as well.

On top of this, we've also removed two questions in the interactive flow:

- It is now only possible to select a single *folder*, instead of multiple files or folders. This eliminates the need for asking whether the user wants to select more. If you were using this before, you will need to manually collect all your files in a folder first.
- Scanning a folder for lots or flora now always happens recursively, which eliminates the question of whether the folder should be scanned recursively. If you do not want to scan a folder recursively, you will need to group the lots first into a separate folder.