### PR TITLE
refactor: use TGI class for `DBPFEntry.tgi`

### DIFF
--- a/src/core/dbpf-entry.ts
+++ b/src/core/dbpf-entry.ts
@@ -304,8 +304,7 @@ export default class Entry<T extends AllowedEntryType = AllowedEntryType> {
 		return 'DBPF Entry '+defaultInspect({
 			dbpf: this.dbpf.file,
 			type: inspect.type(label) ?? inspect.hex(this.type),
-			group: inspect.hex(this.group),
-			instance: inspect.hex(this.instance),
+			tgi: this.tgi,
 			fileSize: this.fileSize,
 			compressedSize: this.compressedSize,
 			offset: this.offset,
@@ -317,7 +316,6 @@ export default class Entry<T extends AllowedEntryType = AllowedEntryType> {
 	}
 
 }
-
 
 // Typing the code below is extremely hard, lol. It shouldn't be, so we 
 // shamelessly use "any". It's internal code anyway.

--- a/src/core/dbpf.ts
+++ b/src/core/dbpf.ts
@@ -12,6 +12,7 @@ import { SmartBuffer } from 'smart-arraybuffer';
 import type { TGIArray, TGILiteral, TGIQuery, uint32 } from 'sc4/types';
 import type { FindParameters } from 'src/utils/tgi-index.js';
 import type { DBPFFile, DecodedFileTypeId, FileTypeId } from './types.js';
+import TGI from './tgi.js';
 
 export type DBPFOptions = {
 	file?: string;
@@ -144,7 +145,7 @@ export default class DBPF {
 			throw new TypeError(`Added file with tgi ${tgi} is undefined!`);
 		}
 		let entry = new Entry({ dbpf: this });
-		entry.tgi = tgi;
+		entry.tgi = new TGI(tgi);
 		this.entries.add(entry);
 		if (isUint8Array(fileOrBuffer)) {
 

--- a/src/core/tgi.ts
+++ b/src/core/tgi.ts
@@ -48,6 +48,11 @@ export default class TGI<T extends uint32 = uint32> {
 		return [this.type, this.group, this.instance];
 	}
 
+	// ## map()
+	map(...args: Parameters<Array<number>['map']>) {
+		return this.toArray().map(...args);
+	}
+
 	*[Symbol.iterator]() {
 		yield* this.toArray();
 	}

--- a/src/core/tgi.ts
+++ b/src/core/tgi.ts
@@ -54,7 +54,9 @@ export default class TGI<T extends uint32 = uint32> {
 	}
 
 	*[Symbol.iterator]() {
-		yield* this.toArray();
+		yield this.type;
+		yield this.group;
+		yield this.instance;
 	}
 
 }

--- a/src/plugins/dependency-tracker.ts
+++ b/src/plugins/dependency-tracker.ts
@@ -924,8 +924,8 @@ class File extends String {
 	}
 }
 class TableTGI {
-	tgi: TGIArray;
-	constructor(tgi: TGIArray) {
+	tgi: TGI;
+	constructor(tgi: TGI) {
 		this.tgi = tgi;
 	}
 	[Symbol.for('nodejs.util.inspect.custom')](_depth: number, opts: any) {


### PR DESCRIPTION
DBPF entries now have an actual TGI class as their `.tgi` field. The `type`, `group` and `instance` fields are now getters that proxy to the underlying TGI class.