### PR TITLE
fix: properly handle 32-bit fsh decompression

### DIFF
--- a/src/core/bitmap-decompression.ts
+++ b/src/core/bitmap-decompression.ts
@@ -16,20 +16,9 @@ export function decompress8bit(data: Uint8Array) {
 
 // # decompress32bit(data)
 // Decompresses a 32-bit encoded bitmap - which actually is no decompressing at 
-// all. The only thing that changes is the order because alpha goes first here.
+// all.
 export function decompress32bit(data: Uint8Array) {
-	const output = new Uint8Array(data.byteLength);
-	for (let i = 0; i < data.length; i += 4) {
-		let a = data[i];
-		let r = data[i+1];
-		let g = data[i+2];
-		let b = data[i+3];
-		output[i] = r;
-		output[i+1] = g;
-		output[i+2] = b;
-		output[i+3] = a;
-	}
-	return output;
+	return data;
 }
 
 // # decompress24bit(data)

--- a/src/core/test/fsh-tests.ts
+++ b/src/core/test/fsh-tests.ts
@@ -48,10 +48,10 @@ describe('The FSH file type', function() {
 		let fsh = new FSH().parse(buffer);
 		let bitmap = fsh.entries[0].image.decompress();
 		expect(bitmap).to.eql(new Uint8Array([
-			0, 0, 0xff, 0,
-			0, 0, 0xff, 0,
-			0, 0, 0xff, 0,
-			0, 0, 0xff, 0,
+			0, 0, 0, 0xff,
+			0, 0, 0, 0xff,
+			0, 0, 0, 0xff,
+			0, 0, 0, 0xff,
 		]));
 
 	});


### PR DESCRIPTION
For some reason we thought that 32-bit bitmaps had their alpha values come first, but this doesn't seem to be the case, so we've undone it again.