### PR TITLE
feat: optionally reset existing submenus

### DIFF
--- a/src/cli/commands/scan-for-menus-command.ts
+++ b/src/cli/commands/scan-for-menus-command.ts
@@ -17,10 +17,17 @@ type Menu = {
 	order?: number;
 };
 
+type ScanForMenusOptions = {
+	override?: boolean;
+};
+
 // # scanForMenus()
 // Performs a scan of the user's plugin folder and reports any submenus found in 
 // it.
-export async function scanForMenus(folder = process.env.SC4_PLUGINS) {
+export async function scanForMenus(
+	folder = process.env.SC4_PLUGINS,
+	opts: ScanForMenusOptions = {},
+) {
 	const queue = new PQueue({ concurrency: 4096 });
 	let glob = new FileScanner('**/*', { cwd: folder });
 	let tasks = [];
@@ -54,8 +61,10 @@ export async function scanForMenus(folder = process.env.SC4_PLUGINS) {
 	// to not override!
 	let configMenus = config.get('menus') || [];
 	let map = new Map();
-	for (let menu of configMenus) {
-		map.set(menu.id, menu);
+	if (!opts.override) {
+		for (let menu of configMenus) {
+			map.set(menu.id, menu);
+		}
 	}
 	let added = 0;
 	for (let menu of menus) {
@@ -69,7 +78,11 @@ export async function scanForMenus(folder = process.env.SC4_PLUGINS) {
 	} else {
 		config.delete('menus');
 	}
-	logger.ok(`Added ${added} new menus to your menu config`);
+	if (opts.override) {
+		logger.ok(`Added ${added} menus to your menu config`);
+	} else {
+		logger.ok(`Added ${added} new menus to your menu config`);
+	}
 
 }
 

--- a/src/cli/flows/scan-for-menus-flow.js
+++ b/src/cli/flows/scan-for-menus-flow.js
@@ -16,5 +16,9 @@ export async function scanForMenus() {
 			filter: info => info.isDirectory(),
 		});
 	}
-	return [plugins];
+	let override = await prompts.confirm({
+		message: `Do you want to reset your current submenus configuration? If you choose "Yes", then only the submenus found by this command will be available when adding lots to a submenu.`,
+		default: false,
+	});
+	return [plugins, { override }];
 }

--- a/src/core/dbpf.ts
+++ b/src/core/dbpf.ts
@@ -321,6 +321,14 @@ export default class DBPF {
 		}
 	}
 
+	// ## createIndex()
+	// We no longer automatically index all entries in the dbpf. Instead it 
+	// needs to be called manually. It's still advised to do on large dbpf files.
+	createIndex() {
+		this.entries.build();
+		return this;
+	}
+
 	// ## save(opts)
 	// Saves the DBPF to a file. Note: we're going to do this in a sync way, 
 	// it's just easier.


### PR DESCRIPTION
This PR adds a new option to the flow for scanning submenus. You now have the option to reset your current submenus config, which is useful if you're now using a different plugins folder.