### PR TITLE
fix: too many open files when tracking deps

### DIFF
--- a/src/plugins/directory-scan-operation.ts
+++ b/src/plugins/directory-scan-operation.ts
@@ -1,10 +1,11 @@
 // # directory-scan-operation.ts
+import PQueue from 'p-queue';
 import { DBPF, FileType, type Entry } from 'sc4/core';
 import createLoadComparator from './create-load-comparator.js';
 import type PluginIndex from './plugin-index.js';
 
 export type Glob = {
-	[Symbol.asyncIterator]: () => AsyncGenerator<File | string | Uint8Array, void, void>;
+	[Symbol.asyncIterator]: () => AsyncGenerator<File | string, void, void>;
 }
 
 type QueueItem = {
@@ -25,19 +26,24 @@ export default class DirectoryScanOperation {
 	}
 	async start() {
 
+		// We need a promise queue so that we can limit the amount of read 
+		// operations we do in parallel. If we don't do this, we might run into 
+		// a EMFILE too many open files error.
+		const q = new PQueue({ concurrency: 500 });
+
 		// First we'll look up all the dbpf files in this folder. Once we have 
 		// the files, we can already resolve this promise so that a progress 
 		// indicator might show how many files we have found in total, while 
 		// being non-blocking to wait for it.
 		const tasks: Promise<any>[] = [];
 		for await (let file of this.glob) {
-			const dbpf = new DBPF(file);
+			const dbpf = new DBPF({ file, parse: false });
 			this.dbpfs.push(dbpf);
 
 			// Immediately start reading in the DBPF.
 			const item: QueueItem = { dbpf, entries: [] };
 			this.queue.push(item);
-			const task = dbpf.parseAsync().then(() => {
+			const task = q.add(() => dbpf.parseAsync()).then(() => {
 				for (let entry of dbpf) {
 					if (entry.type !== FileType.DIR) {
 						item.entries.push(entry);
@@ -50,7 +56,7 @@ export default class DirectoryScanOperation {
 		this.filesPromise.resolve(this.dbpfs);
 
 		// If we reach this point, all dbpfs have been added to the queue and 
-		// they have started loading. This means that we can sort them now based 
+		// they have started loading. This means that we can sort them now based
 		// on the load order that is required!
 		const compare = createLoadComparator();
 		this.queue.sort((a, b) => compare(a.dbpf.filename, b.dbpf.filename));


### PR DESCRIPTION
Apparently we didn't throttle the dependency tracking code, which may cause it to crash because there are too many open file handles in very large plugin folders. This PR fixes that.