### PR TITLE
fix: ignore props placed out of a city tile

### DIFF
--- a/src/api/city-manager.ts
+++ b/src/api/city-manager.ts
@@ -370,10 +370,21 @@ export default class CityManager {
 		// the lot, orienting it and then adding the city offset to it.
 		let position = getOrientedPosition({ lot, lotObject })
 			.add([16*lot.minX, 0, 16*lot.minZ]);
-		let exemplar = this.index.getHierarchicExemplar(exemplarEntry.read());
+
+		// There are cases apparently where a prop has been misplaced, causing 
+		// it to fall outside the city. Props like these won't be added 
+		// obviously.
+		const { metricWidth, metricDepth } = this.city;
+		if (
+			position.x < 0 ||
+			position.y < 0 ||
+			position.x > metricWidth ||
+			position.z > metricDepth
+		) return false;
 
 		// At last insert the prop as well.
-		return this.createProp({
+		let exemplar = this.index.getHierarchicExemplar(exemplarEntry.read());
+		this.createProp({
 			exemplar,
 			tgi: new TGI(exemplarEntry.tgi),
 			position,
@@ -381,6 +392,7 @@ export default class CityManager {
 			OID,
 			lotType: 0x02,
 		});
+		return true;
 
 	}
 

--- a/src/core/savegame.ts
+++ b/src/core/savegame.ts
@@ -102,6 +102,26 @@ export default class Savegame extends DBPF {
 		return 64*this.regionView.zSize;
 	}
 
+	// ## get tileWidth()
+	get tileWidth() {
+		return this.width;
+	}
+
+	// ## get tileDepth()
+	get tileDepth() {
+		return this.depth;
+	}
+
+	// ## get metricWidth()
+	get metricWidth() {
+		return 16*this.tileWidth;
+	}
+
+	// ## get tileDepth()
+	get metricDepth() {
+		return 16*this.tileDepth;
+	}
+
 	// ## createContext()
 	// Returns a Savegame context object that allows us to dereference pointers, 
 	// as well as generate new unique pointer addresses.


### PR DESCRIPTION
While using the `sc4 city plop` command, we noticed that it would crash over props that are incorrectly placed on a lot. If a prop were to be positioned *outside* a lot - and hence possibly outside the city - then we can't determine the terrain height for it and are not able to insert it in the item index properly, so things are going wrong.

This PR fixes this by simply ignoring any props that would fall outside a city tile. Note that props can still be positioned outside a lot though.