### PR TITLE
feat: automatically invalidate corrupt configuration

### DIFF
--- a/src/cli/commands/interactive-command.js
+++ b/src/cli/commands/interactive-command.js
@@ -120,6 +120,12 @@ async function start(n) {
 				await commands.plopAll(...args);
 			},
 		},
+		{
+			name: 'Edit sc4 configuration file',
+			async value() {
+				await commands.config();
+			},
+		},
 	];
 
 	// If the program was called with an existing SimCity 4 savegame, we'll 

--- a/src/cli/setup-env.js
+++ b/src/cli/setup-env.js
@@ -132,8 +132,19 @@ async function findResourceFile() {
 // # ensureFolder(name, paths)
 async function ensureFolder(name, paths) {
 	let folder = config.get(`folders.${name}`);
-	if (folder) return folder;
-	else if (folder === false) return process.cwd();
+
+	// If a folder was specified, but it does no longer exist, then we have to 
+	// look for it again, so don't return early.
+	if (folder) {
+		try {
+			await fs.promises.stat(folder);
+			return folder;
+		} catch (e) {
+			if (e.code !== 'ENOENT') {
+				throw e;
+			}
+		}
+	} else if (folder === false) return process.cwd();
 
 	// If the folder has not been set in the config, search for it in the 
 	// filesystem.


### PR DESCRIPTION
This PR changes two things:

- It adds an option to view and edit the configuration file in interactive mode
- It will now automatically look for a new plugin or regions folder if the configured folder no longer exists