### PR TITLE
feat: add Boats, Ships & Watercraft menu

### DIFF
--- a/src/cli/data/standard-menus.js
+++ b/src/cli/data/standard-menus.js
@@ -54,6 +54,7 @@ const Menu = Object.freeze({
 			Canals: 0x03C6629C,
 			Seawalls: 0x1CD18678,
 			Waterfront: 0x84D42CD6,
+			'Boats, Ships & Watercraft': 0xDD5DC0E7,
 		},
 	},
 	Utilities: {


### PR DESCRIPTION
Adds the new Boats, Ships & Watercraft submenu to the list of default submenus (see also [this comment](https://community.simtropolis.com/files/file/36664-sc4-cli-tool/?do=findComment&comment=662986)).