### PR TITLE
fix: fix #115

### DIFF
--- a/src/cli/setup-cli.js
+++ b/src/cli/setup-cli.js
@@ -8,7 +8,7 @@ import { program as commander, Command } from 'commander';
 import * as commands from '#cli/commands';
 import { DBPF, FileType } from 'sc4/core';
 import * as api from 'sc4/api';
-import { hex } from 'sc4/utils';
+import { hex, inspect } from 'sc4/utils';
 import * as parsers from './parsers.js';
 import version from './version.js';
 
@@ -235,20 +235,25 @@ export function factory(program) {
 			let byte = 'flag1 flag2 flag3 zoneType zoneWealth unknown5 orientation type debug'.split(' ');
 			function replacer(name, val) {
 				if (name === 'commuteBuffer') return val ? '...' : null;
-				else if (dword.includes(name)) return hex(val);
-				else if (byte.includes(name)) return hex(val, 2);
-				else if (word.includes(name)) return hex(val, 4);
+				else if (dword.includes(name)) return inspect.hex(val);
+				else if (byte.includes(name)) return inspect.hex(val, 2);
+				else if (word.includes(name)) return inspect.hex(val, 4);
+				else if (typeof val === 'bigint') return inspect.bigint(val);
 				else return val;
+			}
+			function transform(obj) {
+				const out = {};
+				for (let [key, value] of Object.entries(obj)) {
+					out[key] = replacer(key, value);
+				}
+				return out;
 			}
 
 			let dbpf = new DBPF(buff);
 			let lots = dbpf.find({ type: FileType.Lot }).read();
-			let all = [];
 			for (let lot of lots) {
-				let str = JSON.stringify(lot, replacer, 2);
-				all.push(str);
+				console.log(transform(lot));
 			}
-			console.log(all.join('\n\n-----------------\n\n'));
 
 		});
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -87,6 +87,13 @@ export const inspect = {
 			},
 		};
 	},
+	bigint(value: bigint) {
+		return {
+			[Symbol.for('nodejs.util.inspect.custom')](_depth: number, opts: InspectOptionsStylized) {
+				return opts.stylize(`${value}n`, 'bigint');
+			},
+		};
+	},
 	tgi(object: Partial<TGILiteral>, label?: string) {
 		return {
 			[Symbol.for('nodejs.util.inspect.custom')](_depth: number, opts: InspectOptionsStylized, nodeInspect: Function) {


### PR DESCRIPTION
This PR fixes #115. There reason was that `sc4 misc dump` is an old command, which didn't take into account yet that bigints can't be serialized as json yet. We fix this by simply logging the lots to the console now instead of using `JSON.stringify`.